### PR TITLE
fix(#14): add release-pr job to release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,28 +1,52 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
 
-concurrency:
-  group: release-plz-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release:
-    name: Release
+  release-pr:
+    name: Release PR
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Fixes the incomplete release-plz workflow that was permanently stuck at v0.1.1 because the release-pr job was missing.

Root cause: .github/workflows/release-plz.yml only had the release command (publishes already-tagged versions) but was missing release-pr (reads conventional commits, bumps Cargo.toml, opens version bump PR with CHANGELOG entry).

Changes:
- Add release-pr job that creates/updates version bump PRs on every push to main
- Move concurrency to job level with separate groups (allows parallel execution)
- Add persist-credentials: false to both checkout steps (security hardening)
- Add CARGO_REGISTRY_TOKEN to both jobs for registry access
- Both jobs run independently — no needs: dependency

Expected behaviour after merge: release-plz will open a PR bumping Cargo.toml to v0.1.2 with a CHANGELOG entry covering the lib.rs feature from PR #13.

Closes #14