### PR TITLE
fix(#18): upgrade ort from rc.10 to rc.11 and fix inputs() API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ clap = { version = "4.5", features = ["derive"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 
 # ONNX Runtime for embeddings (CPU-only, auto-downloads shared library)
-# Pinned to RC 10: Stable 2.0.0 not released (latest stable: 1.18.0 with API incompatibilities).
-# RC 11+ has breaking API changes (.inputs field → .inputs() method).
-# RC 10 is the latest compatible version with our Session::inputs field access.
-ort = { version = "=2.0.0-rc.10", features = ["ndarray"] }
+# RC 11 provides lighter dependency footprint (hmac-sha256, lzma-rust2 instead of flate2, sha2, tar).
+# Stable 2.0.0 not released (latest stable: 1.18.0 with API incompatibilities).
+# Requires API changes: .inputs field → .inputs() method, input.name field → input.name() method.
+ort = { version = "=2.0.0-rc.11", features = ["ndarray"] }
 
 # HuggingFace tokenizers and model download
 tokenizers = "0.22.0"

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -64,9 +64,9 @@ impl EmbeddingEngine {
 
         // Check if model requires token_type_ids input
         let requires_token_type_ids = session
-            .inputs
+            .inputs()
             .iter()
-            .any(|input| input.name == "token_type_ids");
+            .any(|input| input.name() == "token_type_ids");
 
         Ok(EmbeddingEngine {
             session,


### PR DESCRIPTION
## Summary

Upgrades ort from `=2.0.0-rc.10` to `=2.0.0-rc.11` to resolve dependency conflicts with downstream consumers (e.g. colgrep via next-plaid-onnx) that require rc.11.

**Changes:**
- `Cargo.toml`: ort bumped to `=2.0.0-rc.11`, comments updated
- `src/embedding.rs`: two mechanical API fixes for rc.11:
  - `.inputs` field → `.inputs()` method (Session API)
  - `input.name` field → `input.name()` method (Outlet API)

**Verified via Context7 docs** — only two breaking API changes between rc.10 and rc.11, both addressed.

All 181 tests pass. Zero clippy warnings. Zero format issues.

Closes #18