### PR TITLE
fix(#25): pin macOS runner to macos-14 for ort rc.11 Xcode 15.4 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-
 pr-run-mode = "upload"
 
 [workspace.metadata.dist.github-custom-runners]
-aarch64-apple-darwin = "macos-latest"
+aarch64-apple-darwin = "macos-14"
 aarch64-unknown-linux-gnu = "ubicloud-standard-4-arm"
 x86_64-unknown-linux-gnu = "ubicloud-standard-4"
 global = "ubicloud-standard-2"


### PR DESCRIPTION
## Summary

- Pins `aarch64-apple-darwin` cargo-dist runner to `macos-14` (was `macos-latest`)
- Removes the previously added xcode-select step from `release.yml` (not needed — Xcode 15.4 is the default on macOS 14)

## Why

`macos-latest` is now macOS 15 (since Sept 2025). macOS 15 only has Xcode 16.x. ort 2.0.0-rc.11's prebuilt macOS ARM64 binary was compiled against Xcode 15.4 / clang 15.0.0, causing link failure on macOS 15:

```
ld: library 'clang_rt.osx' not found
```

macOS 14 has Xcode 15.4 as its default — no xcode-select step needed.

Fixes #25