### PR TITLE
docs: replace hardcoded version tag with cargo install from crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ sudo mv vipune /usr/local/bin/
 
 **Latest release (recommended)**
 ```bash
-# Check https://github.com/randomm/vipune/releases for the latest version
-cargo install --git https://github.com/randomm/vipune --tag v0.1.1 vipune
+cargo install vipune
 ```
 
 **Or clone and build manually**


### PR DESCRIPTION
The cargo install command referenced v0.1.1 while the actual version is
0.1.4. Instead of bumping the tag, use `cargo install vipune` which
always resolves to the latest published crate version — no future
maintenance needed.

Closes #27

https://claude.ai/code/session_01DjQf1gKckELoH1dJy7r3CF