### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-02-28
+
+### Bug Fixes
+
+- Lazy embedding init to prevent flaky tests on HF 404
+- Keep all tests active, cache HF models in CI instead of #[ignore]
+
+
 ## [0.1.4] - 2026-02-27
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vipune"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vipune"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/randomm/vipune"


### PR DESCRIPTION



## 🤖 New release

* `vipune`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5] - 2026-02-28

### Bug Fixes

- Lazy embedding init to prevent flaky tests on HF 404
- Keep all tests active, cache HF models in CI instead of #[ignore]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).