### PR TITLE
feat(#40): upgrade to Rust edition 2024 with MSRV 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "vipune"
 version = "0.1.7"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/randomm/vipune"
 homepage = "https://github.com/randomm/vipune"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -165,8 +165,9 @@ mod tests {
             "VIPUNE_RECENCY_WEIGHT",
         ];
         for var in vars {
-            #[allow(clippy::disallowed_methods)]
-            std::env::remove_var(var);
+            unsafe {
+                std::env::remove_var(var);
+            }
         }
     }
 

--- a/src/config/overrides.rs
+++ b/src/config/overrides.rs
@@ -37,8 +37,9 @@ mod tests {
             "VIPUNE_RECENCY_WEIGHT",
         ];
         for var in vars {
-            #[allow(clippy::disallowed_methods)]
-            std::env::remove_var(var);
+            unsafe {
+                std::env::remove_var(var);
+            }
         }
     }
 
@@ -47,14 +48,12 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_DATABASE_PATH", "/custom/path/db.db");
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_EMBEDDING_MODEL", "env/model");
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_MODEL_CACHE", "/custom/cache");
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_SIMILARITY_THRESHOLD", "0.95");
+        unsafe {
+            std::env::set_var("VIPUNE_DATABASE_PATH", "/custom/path/db.db");
+            std::env::set_var("VIPUNE_EMBEDDING_MODEL", "env/model");
+            std::env::set_var("VIPUNE_MODEL_CACHE", "/custom/cache");
+            std::env::set_var("VIPUNE_SIMILARITY_THRESHOLD", "0.95");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();
@@ -84,8 +83,9 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_SIMILARITY_THRESHOLD", "invalid");
+        unsafe {
+            std::env::set_var("VIPUNE_SIMILARITY_THRESHOLD", "invalid");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();
@@ -111,8 +111,9 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_DATABASE_PATH", "");
+        unsafe {
+            std::env::set_var("VIPUNE_DATABASE_PATH", "");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();
@@ -138,8 +139,9 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_EMBEDDING_MODEL", "   ");
+        unsafe {
+            std::env::set_var("VIPUNE_EMBEDDING_MODEL", "   ");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();
@@ -165,8 +167,9 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_RECENCY_WEIGHT", "0.5");
+        unsafe {
+            std::env::set_var("VIPUNE_RECENCY_WEIGHT", "0.5");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();
@@ -193,8 +196,9 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         cleanup_env_vars();
 
-        #[allow(clippy::disallowed_methods)]
-        std::env::set_var("VIPUNE_RECENCY_WEIGHT", "invalid");
+        unsafe {
+            std::env::set_var("VIPUNE_RECENCY_WEIGHT", "invalid");
+        }
 
         let mut database_path = PathBuf::from("/default");
         let mut embedding_model = "default/model".to_string();

--- a/src/config/tests_utils.rs
+++ b/src/config/tests_utils.rs
@@ -8,7 +8,8 @@ pub static ENV_MUTEX: Mutex<()> = Mutex::new(());
 /// Clean up environment variables used by vipune config.
 pub fn cleanup_env_vars(vars: &[&str]) {
     for var in vars {
-        #[allow(clippy::disallowed_methods)]
-        std::env::remove_var(var);
+        unsafe {
+            std::env::remove_var(var);
+        }
     }
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -4,8 +4,8 @@
 
 use hf_hub::api::sync::Api;
 use ort::inputs;
-use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
+use ort::session::builder::GraphOptimizationLevel;
 use ort::value::Tensor;
 use tokenizers::Tokenizer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,10 @@ mod temporal;
 
 // Re-export public API
 pub use config::Config;
-pub use embedding::{EmbeddingEngine, EMBEDDING_DIMS};
+pub use embedding::{EMBEDDING_DIMS, EmbeddingEngine};
 pub use errors::Error;
-pub use memory::store::{MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};
 pub use memory::MemoryStore;
+pub use memory::store::{MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};
 pub use memory_types::{AddResult, ConflictMemory};
 pub use project::detect_project;
 pub use sqlite::Memory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use commands::Commands;
 use errors::Error;
 use memory::MemoryStore;
-use output::{print_json, ErrorResponse};
+use output::{ErrorResponse, print_json};
 use project::detect_project;
 use std::process::ExitCode;
 

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -3,9 +3,9 @@
 use crate::errors::Error;
 use crate::rrf;
 use crate::sqlite::Memory;
-use crate::temporal::{apply_recency_weight, validate_recency_weight, DecayConfig};
+use crate::temporal::{DecayConfig, apply_recency_weight, validate_recency_weight};
 
-use super::store::{validate_limit, MemoryStore};
+use super::store::{MemoryStore, validate_limit};
 
 /// Maximum allowed candidate pool size for hybrid search to prevent DoS.
 const MAX_CANDIDATE_POOL: usize = 10_000;

--- a/src/memory/tests.rs
+++ b/src/memory/tests.rs
@@ -324,9 +324,11 @@ fn test_hybrid_search_basic() {
 
     // Rust memory should appear in both semantic and BM25 results
     assert!(semantic_results.iter().any(|m| m.id == id_rust));
-    assert!(bm25_results
-        .iter()
-        .any(|m| m.content.to_lowercase().contains("rust")));
+    assert!(
+        bm25_results
+            .iter()
+            .any(|m| m.content.to_lowercase().contains("rust"))
+    );
 }
 
 #[test]

--- a/src/project.rs
+++ b/src/project.rs
@@ -204,9 +204,13 @@ mod tests {
     #[test]
     fn test_env_var_whitespace() {
         // This test runs in isolation, safe to set env var
-        std::env::set_var("VIPUNE_PROJECT", "   ");
+        unsafe {
+            std::env::set_var("VIPUNE_PROJECT", "   ");
+        }
         let project = detect_project(None);
         assert!(!project.is_empty()); // Should ignore whitespace and use fallback
-        std::env::remove_var("VIPUNE_PROJECT");
+        unsafe {
+            std::env::remove_var("VIPUNE_PROJECT");
+        }
     }
 }

--- a/src/sqlite/mod.rs
+++ b/src/sqlite/mod.rs
@@ -12,7 +12,7 @@ pub mod fts;
 pub mod search;
 
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension, Result as SqliteResult};
+use rusqlite::{Connection, OptionalExtension, Result as SqliteResult, params};
 use std::path::Path;
 use uuid::Uuid;
 

--- a/src/sqlite/search.rs
+++ b/src/sqlite/search.rs
@@ -1,6 +1,6 @@
 //! Semantic search and similarity operations.
 
-use super::{embedding, Database, Error, Memory};
+use super::{Database, Error, Memory, embedding};
 use crate::memory::store::MAX_SEARCH_LIMIT;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tests/lib_integration.rs
+++ b/tests/lib_integration.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::path::PathBuf;
 
 use vipune::errors::Error;
-use vipune::{detect_project, Config, MemoryStore, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};
+use vipune::{Config, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT, MemoryStore, detect_project};
 
 /// Test basic memory add and search operations.
 #[test]
@@ -153,11 +153,13 @@ fn test_search_with_oversized_input_returns_error() {
 #[test]
 fn test_config_default_with_no_env_vars_returns_valid_config() {
     // Clear environment variables that might affect config
-    env::remove_var("VIPUNE_DATABASE_PATH");
-    env::remove_var("VIPUNE_EMBEDDING_MODEL");
-    env::remove_var("VIPUNE_MODEL_CACHE");
-    env::remove_var("VIPUNE_SIMILARITY_THRESHOLD");
-    env::remove_var("VIPUNE_RECENCY_WEIGHT");
+    unsafe {
+        env::remove_var("VIPUNE_DATABASE_PATH");
+        env::remove_var("VIPUNE_EMBEDDING_MODEL");
+        env::remove_var("VIPUNE_MODEL_CACHE");
+        env::remove_var("VIPUNE_SIMILARITY_THRESHOLD");
+        env::remove_var("VIPUNE_RECENCY_WEIGHT");
+    }
 
     let config = Config::default();
 


### PR DESCRIPTION
## Summary

Upgrades vipune from Rust edition 2021 to edition 2024, setting minimum supported Rust version to 1.85.

Fixes #40

## Changes

- **Cargo.toml**: `edition = "2024"`, `rust-version = "1.85"`
- **Test code**: Wrapped `std::env::set_var()` and `std::env::remove_var()` in `unsafe` blocks (required by edition 2024)
- **Import ordering**: Reformatted by `cargo fmt` for edition 2024 style
- **Removed stale allows**: Cleaned up `#[allow(clippy::disallowed_methods)]` no longer needed

## Verification

- ✅ `cargo fmt --check` passes
- ✅ `cargo clippy -- -D warnings` passes (0 warnings)
- ✅ `cargo test` passes (315 tests, 309 passed, 6 ignored)
- ✅ Adversarial review: APPROVED

## Risk

LOW — No unsafe code in production paths. All `unsafe` blocks are in test code only (env var manipulation).