### PR TITLE
feat(#64): add batch ingest API with per-item outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,25 @@ for memory in results {
 }
 ```
 
+```rust
+use vipune::{Config, MemoryStore, memory_types::{BatchIngestItem, IngestPolicy}};
+
+// Batch ingest multiple memories
+let items = vec![
+    BatchIngestItem::new("First memory".to_string()),
+    BatchIngestItem::with_metadata("Second memory".to_string(), r#"{"tag": "important"}"#.to_string()),
+];
+
+let outcome = store.batch_ingest(&project_id, &items, IngestPolicy::ConflictAware)
+    .expect("Batch ingest failed");
+
+println!("Added: {}, Conflicts: {}, Errors: {}",
+    outcome.summary.added,
+    outcome.summary.conflicts,
+    outcome.summary.errors
+);
+```
+
 **See the crate documentation at [docs.rs](https://docs.rs/vipune) for complete API reference.**
 
 ## Configuration

--- a/src/config/tests_utils.rs
+++ b/src/config/tests_utils.rs
@@ -4,12 +4,3 @@ use std::sync::Mutex;
 
 /// Mutex to serialize environment variable tests and prevent race conditions.
 pub static ENV_MUTEX: Mutex<()> = Mutex::new(());
-
-/// Clean up environment variables used by vipune config.
-pub fn cleanup_env_vars(vars: &[&str]) {
-    for var in vars {
-        unsafe {
-            std::env::remove_var(var);
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,30 @@
 //!     println!("{:.2}: {}", memory.similarity.unwrap_or(0.0), memory.content);
 //! }
 //! ```
+
+//! # Batch Ingest Example
+//!
+//! ```no_run
+//! # use vipune::{Config, MemoryStore, BatchIngestItem, IngestPolicy};
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! # let config = Config::default();
+//! # let mut store = MemoryStore::new(
+//! #     config.database_path.as_path(),
+//! #     &config.embedding_model,
+//! #     config.clone()
+//! # )?;
+//!
+//! let items = vec![
+//!     BatchIngestItem::new("First memory".to_string()),
+//!     BatchIngestItem::with_metadata("Second memory".to_string(), r#"{"tag": "important"}"#.to_string()),
+//! ];
+//!
+//! let outcome = store.batch_ingest("my-project", &items, IngestPolicy::ConflictAware)?;
+//!
+//! println!("Added: {}, Conflicts: {}", outcome.summary.added, outcome.summary.conflicts);
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! # Mutability Requirements
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ pub use embedding::{EMBEDDING_DIMS, EmbeddingEngine};
 pub use errors::Error;
 pub use memory::MemoryStore;
 pub use memory::store::{MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};
-pub use memory_types::{AddResult, ConflictMemory};
+pub use memory_types::{
+    AddResult, BatchIngestItem, BatchIngestOutcome, BatchIngestResult, BatchIngestSummary,
+    ConflictMemory, IngestPolicy,
+};
 pub use project::detect_project;
 pub use sqlite::Memory;

--- a/src/memory/crud.rs
+++ b/src/memory/crud.rs
@@ -1,7 +1,9 @@
 //! CRUD operations for the memory store.
 
 use crate::errors::Error;
-use crate::memory_types::{AddResult, ConflictMemory};
+use crate::memory_types::{
+    AddResult, BatchIngestItem, BatchIngestOutcome, BatchIngestResult, ConflictMemory, IngestPolicy,
+};
 use crate::sqlite::Memory;
 
 use super::store::MemoryStore;
@@ -128,5 +130,270 @@ impl MemoryStore {
     /// - `Ok(false)` if memory didn't exist
     pub fn delete(&self, id: &str) -> Result<bool, Error> {
         Ok(self.db.delete(id)?)
+    }
+
+    #[must_use = "handle the error or results may be lost"]
+    #[allow(dead_code)]
+    /// Add multiple memories in a single batch operation.
+    ///
+    /// Processes all items independently; mixed outcomes (Added/Conflicts/Error) are supported.
+    /// Results are returned in input order for direct mapping to original items.
+    ///
+    /// # Arguments
+    ///
+    /// * `project_id` - Project identifier (e.g., git repo URL or user-defined)
+    /// * `items` - List of (content, metadata) pairs to ingest
+    /// * `policy` - Conflict policy: ConflictAware checks for conflicts, Force bypasses detection
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(BatchIngestOutcome)` containing per-item results and summary statistics
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - All items fail validation
+    /// - Database backend fails catastrophically
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use vipune::{MemoryStore, Config, memory_types::{BatchIngestItem, IngestPolicy}};
+    /// # let config = Config::default();
+    /// # let mut store = MemoryStore::new(config.database_path.as_path(), &config.embedding_model, config.clone()).unwrap();
+    /// let items = vec![
+    ///     BatchIngestItem::new("First memory".to_string()),
+    ///     BatchIngestItem::with_metadata("Second memory".to_string(), r#"{"tag": "important"}"#.to_string()),
+    /// ];
+    /// let outcome = store.batch_ingest("my-project", &items, IngestPolicy::ConflictAware).unwrap();
+    /// println!("Added: {}, Conflicts: {}", outcome.summary.added, outcome.summary.conflicts);
+    /// ```
+    pub fn batch_ingest(
+        &mut self,
+        project_id: &str,
+        items: &[BatchIngestItem],
+        policy: IngestPolicy,
+    ) -> Result<BatchIngestOutcome, Error> {
+        if items.is_empty() {
+            return Ok(BatchIngestOutcome::new(Vec::new()));
+        }
+
+        let mut results = Vec::with_capacity(items.len());
+
+        for item in items {
+            let result = match Self::validate_input_length(&item.content) {
+                Ok(()) => match self.process_single_item(project_id, item, policy) {
+                    Ok(add_result) => match add_result {
+                        AddResult::Added { id } => BatchIngestResult::Added { id },
+                        AddResult::Conflicts {
+                            proposed,
+                            conflicts,
+                        } => BatchIngestResult::Conflicts {
+                            proposed,
+                            conflicts,
+                        },
+                    },
+                    Err(e) => BatchIngestResult::Error {
+                        message: e.to_string(),
+                    },
+                },
+                Err(e) => BatchIngestResult::Error {
+                    message: e.to_string(),
+                },
+            };
+            results.push(result);
+        }
+
+        Ok(BatchIngestOutcome::new(results))
+    }
+
+    /// Process a single batch item with the given policy.
+    fn process_single_item(
+        &mut self,
+        project_id: &str,
+        item: &BatchIngestItem,
+        policy: IngestPolicy,
+    ) -> Result<AddResult, Error> {
+        if policy == IngestPolicy::Force {
+            let embedding = self.embedder()?.embed(&item.content)?;
+            let id = self.db.insert(
+                project_id,
+                &item.content,
+                &embedding,
+                item.metadata.as_deref(),
+            )?;
+            return Ok(AddResult::Added { id });
+        }
+
+        let embedding = self.embedder()?.embed(&item.content)?;
+        let similars =
+            self.db
+                .find_similar(project_id, &embedding, self.config.similarity_threshold)?;
+        let conflicts: Vec<ConflictMemory> = similars
+            .into_iter()
+            .map(|m| ConflictMemory {
+                id: m.id,
+                content: m.content,
+                similarity: m.similarity.unwrap_or(0.0),
+            })
+            .collect();
+
+        if conflicts.is_empty() {
+            let id = self.db.insert(
+                project_id,
+                &item.content,
+                &embedding,
+                item.metadata.as_deref(),
+            )?;
+            Ok(AddResult::Added { id })
+        } else {
+            Ok(AddResult::Conflicts {
+                proposed: item.content.clone(),
+                conflicts,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::memory_types::BatchIngestItem;
+    use tempfile::NamedTempFile;
+
+    fn create_test_store() -> MemoryStore {
+        let temp_file = NamedTempFile::new().unwrap();
+        let database_path = temp_file.path().to_path_buf();
+        // Keep temp file alive so SQLite can use it
+        std::mem::forget(temp_file);
+        let embedding_model = Config::default().embedding_model;
+        let config = Config {
+            database_path: database_path.clone(),
+            embedding_model: embedding_model.clone(),
+            ..Default::default()
+        };
+        MemoryStore::new(database_path.as_path(), &embedding_model, config).unwrap()
+    }
+
+    #[test]
+    fn batch_all_success() {
+        let mut store = create_test_store();
+        let items = vec![
+            BatchIngestItem::new("The first unique test memory document".to_string()),
+            BatchIngestItem::new("A completely different second document content".to_string()),
+            BatchIngestItem::new("The third separate memory with unique text".to_string()),
+        ];
+
+        let outcome = store
+            .batch_ingest("test-project", &items, IngestPolicy::ConflictAware)
+            .unwrap();
+
+        assert_eq!(outcome.summary.total, 3);
+        assert_eq!(outcome.summary.added, 3);
+        assert_eq!(outcome.summary.conflicts, 0);
+        assert_eq!(outcome.summary.errors, 0);
+
+        assert_eq!(outcome.results.len(), 3);
+        for result in &outcome.results {
+            assert!(matches!(result, BatchIngestResult::Added { .. }));
+        }
+    }
+
+    #[test]
+    fn batch_mixed_outcomes() {
+        let mut store = create_test_store();
+
+        // Add a base memory to create potential conflicts
+        let base_content = "Duplicate content here";
+        store
+            .add_with_conflict("test-project", base_content, None, false)
+            .unwrap();
+
+        let items = vec![
+            BatchIngestItem::new("The quick brown fox jumps over lazy dog".to_string()), // index 0: added
+            BatchIngestItem::new(base_content.to_string()), // index 1: conflicts
+            BatchIngestItem::new(
+                "Gravity is a fundamental force that attracts objects with mass".to_string(),
+            ), // index 2: added
+            BatchIngestItem::new(
+                "Photosynthesis converts light energy into chemical energy".to_string(),
+            ), // index 3: added
+        ];
+
+        let outcome = store
+            .batch_ingest("test-project", &items, IngestPolicy::ConflictAware)
+            .unwrap();
+
+        assert_eq!(outcome.summary.total, 4);
+        assert_eq!(outcome.summary.added, 3);
+        assert_eq!(outcome.summary.conflicts, 1);
+        assert_eq!(outcome.summary.errors, 0);
+
+        assert_eq!(outcome.results.len(), 4);
+
+        // Index mapping: verify results match input order
+        assert!(matches!(
+            outcome.results[0],
+            BatchIngestResult::Added { .. }
+        ));
+        assert!(matches!(
+            outcome.results[1],
+            BatchIngestResult::Conflicts { .. }
+        ));
+        assert!(matches!(
+            outcome.results[2],
+            BatchIngestResult::Added { .. }
+        ));
+        assert!(matches!(
+            outcome.results[3],
+            BatchIngestResult::Added { .. }
+        ));
+
+        // Verify conflict details
+        if let BatchIngestResult::Conflicts { proposed, .. } = &outcome.results[1] {
+            assert_eq!(proposed, base_content);
+        }
+    }
+
+    #[test]
+    fn batch_invalid_input_continues_others() {
+        let mut store = create_test_store();
+
+        // Empty string is invalid input
+        let items = vec![
+            BatchIngestItem::new("Valid memory 1".to_string()), // index 0: added
+            BatchIngestItem::new(String::new()),                // index 1: error (empty)
+            BatchIngestItem::new("Valid memory 2".to_string()), // index 2: added
+        ];
+
+        let outcome = store
+            .batch_ingest("test-project", &items, IngestPolicy::Force)
+            .unwrap();
+
+        assert_eq!(outcome.summary.total, 3);
+        assert_eq!(outcome.summary.added, 2);
+        assert_eq!(outcome.summary.conflicts, 0);
+        assert_eq!(outcome.summary.errors, 1);
+
+        assert_eq!(outcome.results.len(), 3);
+
+        assert!(matches!(
+            outcome.results[0],
+            BatchIngestResult::Added { .. }
+        ));
+        assert!(matches!(
+            outcome.results[1],
+            BatchIngestResult::Error { .. }
+        ));
+        assert!(matches!(
+            outcome.results[2],
+            BatchIngestResult::Added { .. }
+        ));
+
+        // Verify error message
+        if let BatchIngestResult::Error { message } = &outcome.results[1] {
+            assert!(message.to_lowercase().contains("input cannot be empty"));
+        }
     }
 }

--- a/src/memory/crud.rs
+++ b/src/memory/crud.rs
@@ -133,11 +133,30 @@ impl MemoryStore {
     }
 
     #[must_use = "handle the error or results may be lost"]
-    #[allow(dead_code)]
     /// Add multiple memories in a single batch operation.
     ///
     /// Processes all items independently; mixed outcomes (Added/Conflicts/Error) are supported.
     /// Results are returned in input order for direct mapping to original items.
+    ///
+    /// # Deterministic Behavior
+    ///
+    /// - Items are processed sequentially in the order provided
+    /// - Each result at index N corresponds to the input item at index N
+    /// - Invalid items (empty content, content > 100,000 characters) return `Error` but do not stop processing
+    /// - Valid items continue processing even after encountering errors in earlier items
+    ///
+    /// # Input Validation
+    ///
+    /// Each item is validated independently:
+    /// - Empty content → Error result (processing continues)
+    /// - Content exceeding 100,000 characters → Error result (processing continues)
+    /// - Valid content → Proceeds to conflict detection or insertion based on policy
+    ///
+    /// # Performance Note
+    ///
+    /// Batch operations are designed to be non-regressive compared to single-item loops:
+    /// embedding generation and database operations have equivalent overhead per item.
+    /// Use batch API primarily for convenience and atomic result handling, not for performance gains.
     ///
     /// # Arguments
     ///
@@ -168,6 +187,7 @@ impl MemoryStore {
     /// let outcome = store.batch_ingest("my-project", &items, IngestPolicy::ConflictAware).unwrap();
     /// println!("Added: {}, Conflicts: {}", outcome.summary.added, outcome.summary.conflicts);
     /// ```
+    #[allow(dead_code)] // Public API for library consumers, documented in lib.rs
     pub fn batch_ingest(
         &mut self,
         project_id: &str,
@@ -207,6 +227,7 @@ impl MemoryStore {
         Ok(BatchIngestOutcome::new(results))
     }
 
+    #[allow(dead_code)] // Helper for batch_ingest, private API
     /// Process a single batch item with the given policy.
     fn process_single_item(
         &mut self,
@@ -395,5 +416,124 @@ mod tests {
         if let BatchIngestResult::Error { message } = &outcome.results[1] {
             assert!(message.to_lowercase().contains("input cannot be empty"));
         }
+    }
+
+    #[test]
+    fn batch_force_policy_adds_despite_conflicts() {
+        let mut store = create_test_store();
+
+        // Add a base memory
+        let base_content = "Duplicate content here";
+        store
+            .add_with_conflict("test-project", base_content, None, false)
+            .unwrap();
+
+        let items = vec![
+            BatchIngestItem::new(base_content.to_string()), // would conflict with ConflictAware
+            BatchIngestItem::new("Another memory".to_string()),
+        ];
+
+        // With Force policy, all items should be added even with conflicts
+        let outcome = store
+            .batch_ingest("test-project", &items, IngestPolicy::Force)
+            .unwrap();
+
+        assert_eq!(outcome.summary.total, 2);
+        assert_eq!(outcome.summary.added, 2);
+        assert_eq!(outcome.summary.conflicts, 0);
+        assert_eq!(outcome.summary.errors, 0);
+
+        assert!(matches!(
+            outcome.results[0],
+            BatchIngestResult::Added { .. }
+        ));
+        assert!(matches!(
+            outcome.results[1],
+            BatchIngestResult::Added { .. }
+        ));
+    }
+
+    #[test]
+    fn batch_input_length_validation() {
+        let mut store = create_test_store();
+
+        // Create content exceeding MAX_INPUT_LENGTH (100,000 characters)
+        let long_content = "x".repeat(100_001);
+
+        let items = vec![
+            BatchIngestItem::new("Valid memory".to_string()), // index 0: added
+            BatchIngestItem::new(long_content),               // index 1: error (too long)
+        ];
+
+        let outcome = store
+            .batch_ingest("test-project", &items, IngestPolicy::Force)
+            .unwrap();
+
+        assert_eq!(outcome.summary.total, 2);
+        assert_eq!(outcome.summary.added, 1);
+        assert_eq!(outcome.summary.conflicts, 0);
+        assert_eq!(outcome.summary.errors, 1);
+
+        assert!(matches!(
+            outcome.results[0],
+            BatchIngestResult::Added { .. }
+        ));
+        assert!(matches!(
+            outcome.results[1],
+            BatchIngestResult::Error { .. }
+        ));
+
+        // Verify error message
+        if let BatchIngestResult::Error { message } = &outcome.results[1] {
+            assert!(message.to_lowercase().contains("too long"));
+        }
+    }
+
+    // Performance sanity check: batch_ingest should not be significantly slower than single-item loop.
+    // This is a non-regression test, not a microbenchmark. Uses generous threshold and deterministic dataset.
+    // Issue #64: ensure batch API doesn't introduce performance regressions compared to calling add_with_conflict in a loop.
+    #[test]
+    fn performance_sanity_batch_vs_single_item_no_regression() {
+        // Use small, deterministic dataset
+        let items_data: Vec<String> = (0..10)
+            .map(|i| format!("Test memory document number {} with unique content", i))
+            .collect();
+        let items: Vec<BatchIngestItem> = items_data
+            .iter()
+            .cloned()
+            .map(BatchIngestItem::new)
+            .collect();
+
+        // Time batch operation
+        let mut store_batch = create_test_store();
+        let start_batch = std::time::Instant::now();
+        store_batch
+            .batch_ingest("perf-test", &items, IngestPolicy::Force)
+            .unwrap();
+        let batch_duration = start_batch.elapsed();
+
+        // Time single-item loop (equivalent workload: 10 independent add_with_conflict calls)
+        let mut store_loop = create_test_store();
+        let start_loop = std::time::Instant::now();
+        for item in items_data.iter() {
+            store_loop
+                .add_with_conflict("perf-test", item, None, true)
+                .unwrap();
+        }
+        let loop_duration = start_loop.elapsed();
+
+        // Sanity threshold: batch should not be more than 5x slower than loop (generous for debug mode)
+        // If performance regresses significantly, this will catch it without flakiness
+        let max_acceptable_ratio = 5.0;
+        let ratio = batch_duration.as_nanos() as f64 / loop_duration.as_nanos().max(1) as f64;
+
+        assert!(
+            ratio <= max_acceptable_ratio,
+            "Batch operation {}x slower than loop (threshold: {}x)\nBatch: {:?}, Loop: {:?}",
+            ratio,
+            max_acceptable_ratio,
+            batch_duration,
+            loop_duration,
+        );
     }
 }

--- a/src/memory/tests.rs
+++ b/src/memory/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::config::Config;
+use crate::memory_types::{BatchIngestItem, IngestPolicy};
 use crate::sqlite::Database;
 
 #[test]
@@ -407,4 +408,316 @@ fn test_hybrid_search_with_recency() {
         // Either the high-similarity old memory is first, or we have a single result
         assert!(top_id == &id_old || semantic_results.len() == 1);
     }
+}
+
+/// Test that batch_ingest handles empty batch (returns empty outcome).
+#[test]
+fn test_batch_ingest_with_empty_batch_returns_empty_outcome() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    let items: Vec<BatchIngestItem> = Vec::new();
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 0);
+    assert_eq!(outcome.summary.total, 0);
+    assert_eq!(outcome.summary.added, 0);
+    assert_eq!(outcome.summary.conflicts, 0);
+    assert_eq!(outcome.summary.errors, 0);
+}
+
+/// Test that batch_ingest returns results in input order (index mapping).
+#[test]
+fn test_batch_ingest_returns_results_in_input_order() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    let items = vec![
+        BatchIngestItem::new("Elephants live in Africa".to_string()),
+        BatchIngestItem::new("Rust programming language features".to_string()),
+        BatchIngestItem::new("Coffee shops in Seattle".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    // Verify length matches input
+    assert_eq!(outcome.results.len(), 3);
+
+    // Verify results are in input order and all added (use distinct content to avoid conflicts)
+    for (i, result) in outcome.results.iter().enumerate() {
+        if let crate::memory_types::BatchIngestResult::Added { id } = result {
+            assert!(!id.is_empty());
+        } else {
+            panic!("Expected Added at index {}, got: {:?}", i, result);
+        }
+    }
+
+    // Verify all added
+    assert_eq!(outcome.summary.added, 3);
+}
+
+/// Test that batch_ingest handles mixed outcomes (some added, some conflicts).
+#[test]
+fn test_batch_ingest_handles_mixed_outcomes() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let db = Database::open(&path).unwrap();
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    // First, add a memory to create conflicts
+    let existing_content = "Python async programming uses await syntax";
+    let embedding = store.embedder().unwrap().embed(existing_content).unwrap();
+    db.insert("test", existing_content, &embedding, None)
+        .unwrap();
+
+    // Now add a batch with: similar content, different content, overlapping content
+    let items = vec![
+        BatchIngestItem::new("Python async programming uses await syntax".to_string()), // Should conflict
+        BatchIngestItem::new("JavaScript event loop handles callbacks".to_string()), // Should add
+        BatchIngestItem::new("Async programming in Python with await".to_string()), // Should conflict
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 3);
+
+    // First should conflict
+    assert!(matches!(
+        outcome.results[0],
+        crate::memory_types::BatchIngestResult::Conflicts { .. }
+    ));
+
+    // Second should add
+    assert!(matches!(
+        outcome.results[1],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+
+    // Third should conflict
+    assert!(matches!(
+        outcome.results[2],
+        crate::memory_types::BatchIngestResult::Conflicts { .. }
+    ));
+
+    // Verify summary
+    assert_eq!(outcome.summary.added, 1);
+    assert_eq!(outcome.summary.conflicts, 2);
+    assert_eq!(outcome.summary.total, 3);
+}
+
+/// Test that batch_ingest respects IngestPolicy::Force (adds regardless of conflicts).
+#[test]
+fn test_batch_ingest_with_force_policy_adds_all_items() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let db = Database::open(&path).unwrap();
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    // First, add a memory
+    let embedding = store
+        .embedder()
+        .unwrap()
+        .embed("Alice works at Microsoft")
+        .unwrap();
+    db.insert("test", "Alice works at Microsoft", &embedding, None)
+        .unwrap();
+
+    // Batch with Force policy should add duplicate content
+    let items = vec![
+        BatchIngestItem::new("Alice works at Microsoft".to_string()),
+        BatchIngestItem::new("Another memory".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::Force)
+        .expect("Batch ingest should succeed");
+
+    // All should be added despite duplicates
+    assert_eq!(outcome.results.len(), 2);
+    assert!(matches!(
+        outcome.results[0],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+    assert!(matches!(
+        outcome.results[1],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+    assert_eq!(outcome.summary.added, 2);
+}
+
+/// Test that batch_ingest handles invalid input items as errors.
+#[test]
+fn test_batch_ingest_with_invalid_input_items_returns_errors() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    // Mix of valid and invalid items
+    let items = vec![
+        BatchIngestItem::new("Valid content".to_string()),
+        BatchIngestItem::new("".to_string()),    // Empty
+        BatchIngestItem::new("   ".to_string()), // Whitespace only
+        BatchIngestItem::new("Another valid".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 4);
+
+    // First should add
+    assert!(matches!(
+        outcome.results[0],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+
+    // Second should error (empty)
+    assert!(matches!(
+        outcome.results[1],
+        crate::memory_types::BatchIngestResult::Error { .. }
+    ));
+
+    // Third should error (whitespace)
+    assert!(matches!(
+        outcome.results[2],
+        crate::memory_types::BatchIngestResult::Error { .. }
+    ));
+
+    // Fourth should add
+    assert!(matches!(
+        outcome.results[3],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+
+    // Verify summary
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.errors, 2);
+}
+
+/// Test that batch_ingest handles oversized input items as errors.
+#[test]
+fn test_batch_ingest_with_oversized_input_items_returns_errors() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    // Mix of valid and oversized items
+    use super::store::MAX_INPUT_LENGTH;
+    let items = vec![
+        BatchIngestItem::new("Valid content".to_string()),
+        BatchIngestItem::new("x".repeat(MAX_INPUT_LENGTH + 1)), // Too long
+        BatchIngestItem::new("Another valid".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 3);
+
+    // First should add
+    assert!(matches!(
+        outcome.results[0],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+
+    // Second should error (too long)
+    assert!(matches!(
+        outcome.results[1],
+        crate::memory_types::BatchIngestResult::Error { .. }
+    ));
+
+    // Third should add
+    assert!(matches!(
+        outcome.results[2],
+        crate::memory_types::BatchIngestResult::Added { .. }
+    ));
+
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.errors, 1);
+}
+
+/// Test that batch_ingest summary is accurate.
+#[test]
+fn test_batch_ingest_summary_matches_results() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    std::mem::forget(dir);
+
+    let db = Database::open(&path).unwrap();
+    let config = Config::default();
+    let embedding_model = Config::default().embedding_model;
+    let mut store = MemoryStore::new(&path, &embedding_model, config).unwrap();
+
+    // Add one memory for conflicts
+    let embedding = store
+        .embedder()
+        .unwrap()
+        .embed("PostgreSQL is a relational database")
+        .unwrap();
+    db.insert(
+        "test",
+        "PostgreSQL is a relational database",
+        &embedding,
+        None,
+    )
+    .unwrap();
+
+    // Mix of all outcomes
+    let items = vec![
+        BatchIngestItem::new("PostgreSQL is a relational database".to_string()), // Conflict
+        BatchIngestItem::new("Rust ownership system prevents data races".to_string()), // Added
+        BatchIngestItem::new("".to_string()),                                    // Error
+        BatchIngestItem::new("Node.js uses event-driven architecture".to_string()), // Added
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    // Verify summary matches manual count (2 new memories added)
+    assert_eq!(outcome.summary.total, 4);
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.conflicts, 1);
+    assert_eq!(outcome.summary.errors, 1);
 }

--- a/src/memory_types.rs
+++ b/src/memory_types.rs
@@ -32,8 +32,10 @@ pub struct ConflictMemory {
 }
 
 /// Conflict policy for batch ingest operations.
+///
+/// Determines how conflicts are handled during batch ingestion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Public API used by batch_ingest
 pub enum IngestPolicy {
     /// Check for conflicts and refuse to add if conflicts are found.
     ConflictAware,
@@ -42,8 +44,12 @@ pub enum IngestPolicy {
 }
 
 /// Input item for batch ingest operations.
+///
+/// Each item is validated independently during batch ingestion:
+/// - Empty content → Error result (batch continues)
+/// - Content > 100,000 characters → Error result (batch continues)
+/// - Valid content → Proceeds to insertion or conflict detection
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct BatchIngestItem {
     /// Text content to store (1 to 100,000 characters).
     pub content: String,
@@ -51,9 +57,9 @@ pub struct BatchIngestItem {
     pub metadata: Option<String>,
 }
 
-#[allow(dead_code)]
 impl BatchIngestItem {
     /// Create a new batch ingest item.
+    #[allow(dead_code)] // Public API used in lib.rs examples
     pub fn new(content: String) -> Self {
         Self {
             content,
@@ -62,6 +68,7 @@ impl BatchIngestItem {
     }
 
     /// Create a new batch ingest item with metadata.
+    #[allow(dead_code)] // Public API used in lib.rs examples
     pub fn with_metadata(content: String, metadata: String) -> Self {
         Self {
             content,
@@ -75,7 +82,7 @@ impl BatchIngestItem {
 /// Each item in a batch ingest operation returns a `BatchIngestResult`
 /// indicating whether it was added, had conflicts, or encountered an error.
 #[derive(Debug, Serialize)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Public API returned by batch_ingest
 pub enum BatchIngestResult {
     /// Memory was successfully added.
     Added { id: String },
@@ -90,7 +97,7 @@ pub enum BatchIngestResult {
 
 /// Summary statistics for batch ingest operations.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Public API part of BatchIngestOutcome
 pub struct BatchIngestSummary {
     /// Number of items successfully added.
     pub added: usize,
@@ -130,7 +137,7 @@ impl BatchIngestSummary {
 ///
 /// Contains per-item results (in input order) and summary statistics.
 #[derive(Debug, Serialize)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Public API returned by batch_ingest
 pub struct BatchIngestOutcome {
     /// Per-item results, indexed by input order.
     pub results: Vec<BatchIngestResult>,

--- a/src/memory_types.rs
+++ b/src/memory_types.rs
@@ -30,3 +30,118 @@ pub struct ConflictMemory {
     /// Similarity score indicating the degree of conflict (0.0 to 1.0).
     pub similarity: f64,
 }
+
+/// Conflict policy for batch ingest operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum IngestPolicy {
+    /// Check for conflicts and refuse to add if conflicts are found.
+    ConflictAware,
+    /// Bypass conflict detection and add regardless of conflicts.
+    Force,
+}
+
+/// Input item for batch ingest operations.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct BatchIngestItem {
+    /// Text content to store (1 to 100,000 characters).
+    pub content: String,
+    /// Optional JSON metadata string.
+    pub metadata: Option<String>,
+}
+
+#[allow(dead_code)]
+impl BatchIngestItem {
+    /// Create a new batch ingest item.
+    pub fn new(content: String) -> Self {
+        Self {
+            content,
+            metadata: None,
+        }
+    }
+
+    /// Create a new batch ingest item with metadata.
+    pub fn with_metadata(content: String, metadata: String) -> Self {
+        Self {
+            content,
+            metadata: Some(metadata),
+        }
+    }
+}
+
+/// Per-item result for batch ingest operations.
+///
+/// Each item in a batch ingest operation returns a `BatchIngestResult`
+/// indicating whether it was added, had conflicts, or encountered an error.
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+pub enum BatchIngestResult {
+    /// Memory was successfully added.
+    Added { id: String },
+    /// Memory conflicts with existing similar memories.
+    Conflicts {
+        proposed: String,
+        conflicts: Vec<ConflictMemory>,
+    },
+    /// Error processing this item.
+    Error { message: String },
+}
+
+/// Summary statistics for batch ingest operations.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[allow(dead_code)]
+pub struct BatchIngestSummary {
+    /// Number of items successfully added.
+    pub added: usize,
+    /// Number of items with conflicts.
+    pub conflicts: usize,
+    /// Number of items that encountered errors.
+    pub errors: usize,
+    /// Total number of items in the batch.
+    pub total: usize,
+}
+
+impl BatchIngestSummary {
+    /// Calculate summary from a slice of results.
+    fn from_results(results: &[BatchIngestResult]) -> Self {
+        let mut added = 0;
+        let mut conflicts = 0;
+        let mut errors = 0;
+
+        for result in results {
+            match result {
+                BatchIngestResult::Added { .. } => added += 1,
+                BatchIngestResult::Conflicts { .. } => conflicts += 1,
+                BatchIngestResult::Error { .. } => errors += 1,
+            }
+        }
+
+        Self {
+            added,
+            conflicts,
+            errors,
+            total: results.len(),
+        }
+    }
+}
+
+/// Complete result from a batch ingest operation.
+///
+/// Contains per-item results (in input order) and summary statistics.
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+pub struct BatchIngestOutcome {
+    /// Per-item results, indexed by input order.
+    pub results: Vec<BatchIngestResult>,
+    /// Summary statistics.
+    pub summary: BatchIngestSummary,
+}
+
+impl BatchIngestOutcome {
+    /// Create a new batch ingest outcome from results.
+    pub fn new(results: Vec<BatchIngestResult>) -> Self {
+        let summary = BatchIngestSummary::from_results(&results);
+        Self { results, summary }
+    }
+}

--- a/tests/lib_integration.rs
+++ b/tests/lib_integration.rs
@@ -4,7 +4,10 @@ use std::env;
 use std::path::PathBuf;
 
 use vipune::errors::Error;
-use vipune::{Config, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT, MemoryStore, detect_project};
+use vipune::{
+    BatchIngestItem, Config, IngestPolicy, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT, MemoryStore,
+    detect_project,
+};
 
 /// Test basic memory add and search operations.
 #[test]
@@ -595,6 +598,377 @@ fn test_search_hybrid_with_oversized_input_returns_error() {
     } else {
         panic!("Expected InputTooLong error");
     }
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest handles empty batch (returns empty outcome).
+#[test]
+fn test_batch_ingest_with_empty_batch_returns_empty_outcome() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    let items: Vec<BatchIngestItem> = Vec::new();
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 0);
+    assert_eq!(outcome.summary.total, 0);
+    assert_eq!(outcome.summary.added, 0);
+    assert_eq!(outcome.summary.conflicts, 0);
+    assert_eq!(outcome.summary.errors, 0);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest returns results in input order (index mapping).
+#[test]
+fn test_batch_ingest_returns_results_in_input_order() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    let items = vec![
+        BatchIngestItem::new("The first semantic concept involves neural network architecture patterns for deep learning models".to_string()),
+        BatchIngestItem::new("A quantum mechanical principle states that particles exhibit wave like duality with interference patterns observed".to_string()),
+        BatchIngestItem::new("Photosynthesis is a biochemical process where plants convert sunlight into chemical energy stored as glucose".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    // Verify length matches input
+    assert_eq!(outcome.results.len(), 3);
+
+    // Verify results are in input order
+    if let vipune::BatchIngestResult::Added { id } = &outcome.results[0] {
+        assert!(!id.is_empty());
+    } else {
+        panic!("Expected Added at index 0");
+    }
+
+    if let vipune::BatchIngestResult::Added { id } = &outcome.results[1] {
+        assert!(!id.is_empty());
+    } else {
+        panic!("Expected Added at index 1");
+    }
+
+    if let vipune::BatchIngestResult::Added { id } = &outcome.results[2] {
+        assert!(!id.is_empty());
+    } else {
+        panic!("Expected Added at index 2");
+    }
+
+    // Verify all added
+    assert_eq!(outcome.summary.added, 3);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest handles mixed outcomes (some added, some conflicts).
+#[test]
+fn test_batch_ingest_handles_mixed_outcomes() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    // First, add a memory to create conflicts
+    let existing_content = "Alice works at Microsoft";
+    match store
+        .add_with_conflict("test", existing_content, None, false)
+        .unwrap()
+    {
+        vipune::AddResult::Added { .. } => {}
+        _ => panic!("Expected first add to succeed"),
+    }
+
+    // Now add a batch with: similar content, different content, overlapping content
+    let items = vec![
+        BatchIngestItem::new("Alice works at Microsoft".to_string()), // Should conflict
+        BatchIngestItem::new("Different content about Bob".to_string()), // Should add
+        BatchIngestItem::new("Alice works at Microsoft".to_string()), // Should conflict
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 3);
+
+    // First should conflict
+    assert!(matches!(
+        outcome.results[0],
+        vipune::BatchIngestResult::Conflicts { .. }
+    ));
+
+    // Second should add
+    assert!(matches!(
+        outcome.results[1],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    // Third should conflict
+    assert!(matches!(
+        outcome.results[2],
+        vipune::BatchIngestResult::Conflicts { .. }
+    ));
+
+    // Verify summary
+    assert_eq!(outcome.summary.added, 1);
+    assert_eq!(outcome.summary.conflicts, 2);
+    assert_eq!(outcome.summary.total, 3);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest respects IngestPolicy::Force (adds regardless of conflicts).
+#[test]
+fn test_batch_ingest_with_force_policy_adds_all_items() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    // First, add a memory
+    match store
+        .add_with_conflict("test", "Alice works at Microsoft", None, false)
+        .unwrap()
+    {
+        vipune::AddResult::Added { .. } => {}
+        _ => panic!("Expected first add to succeed"),
+    }
+
+    // Batch with Force policy should add duplicate content
+    let items = vec![
+        BatchIngestItem::new("Alice works at Microsoft".to_string()),
+        BatchIngestItem::new("Another memory".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::Force)
+        .expect("Batch ingest should succeed");
+
+    // All should be added despite duplicates
+    assert_eq!(outcome.results.len(), 2);
+    assert!(matches!(
+        outcome.results[0],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+    assert!(matches!(
+        outcome.results[1],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+    assert_eq!(outcome.summary.added, 2);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest handles invalid input items as errors.
+#[test]
+fn test_batch_ingest_with_invalid_input_items_returns_errors() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    // Mix of valid and invalid items
+    let items = vec![
+        BatchIngestItem::new("Valid content".to_string()),
+        BatchIngestItem::new("".to_string()),    // Empty
+        BatchIngestItem::new("   ".to_string()), // Whitespace only
+        BatchIngestItem::new("Another valid".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 4);
+
+    // First should add
+    assert!(matches!(
+        outcome.results[0],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    // Second should error (empty)
+    assert!(matches!(
+        outcome.results[1],
+        vipune::BatchIngestResult::Error { .. }
+    ));
+
+    // Third should error (whitespace)
+    assert!(matches!(
+        outcome.results[2],
+        vipune::BatchIngestResult::Error { .. }
+    ));
+
+    // Fourth should add
+    assert!(matches!(
+        outcome.results[3],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    // Verify summary
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.errors, 2);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest handles oversized input items as errors.
+#[test]
+fn test_batch_ingest_with_oversized_input_items_returns_errors() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    // Mix of valid and oversized items
+    let items = vec![
+        BatchIngestItem::new("Valid content".to_string()),
+        BatchIngestItem::new("x".repeat(MAX_INPUT_LENGTH + 1)), // Too long
+        BatchIngestItem::new("Another valid".to_string()),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 3);
+
+    // First should add
+    assert!(matches!(
+        outcome.results[0],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    // Second should error (too long)
+    assert!(matches!(
+        outcome.results[1],
+        vipune::BatchIngestResult::Error { .. }
+    ));
+
+    // Third should add
+    assert!(matches!(
+        outcome.results[2],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.errors, 1);
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest with metadata works correctly.
+#[test]
+fn test_batch_ingest_with_metadata_stores_metadata() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    let items = vec![
+        BatchIngestItem::with_metadata(
+            "The content includes semantic metadata fields for structured data storage".to_string(),
+            r#"{"key": "value"}"#.to_string(),
+        ),
+        BatchIngestItem::new(
+            "A separate content item without any metadata information attached".to_string(),
+        ),
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    assert_eq!(outcome.results.len(), 2);
+    assert!(matches!(
+        outcome.results[0],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+    assert!(matches!(
+        outcome.results[1],
+        vipune::BatchIngestResult::Added { .. }
+    ));
+
+    // Verify metadata was stored
+    if let vipune::BatchIngestResult::Added { id } = &outcome.results[0] {
+        let memory = store
+            .get(id)
+            .expect("Failed to get memory")
+            .expect("Memory not found");
+        assert_eq!(memory.metadata, Some(r#"{"key": "value"}"#.to_string()));
+    }
+
+    if let vipune::BatchIngestResult::Added { id } = &outcome.results[1] {
+        let memory = store
+            .get(id)
+            .expect("Failed to get memory")
+            .expect("Memory not found");
+        assert_eq!(memory.metadata, None);
+    }
+
+    std::fs::remove_file(db_path).ok();
+}
+
+/// Test that batch_ingest summary is accurate.
+#[test]
+fn test_batch_ingest_summary_matches_results() {
+    let temp_dir = env::temp_dir();
+    let db_path = temp_dir.join(format!("vipune_test_{}.db", uuid::Uuid::new_v4()));
+
+    let config = Config::default();
+    let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
+        .expect("Failed to create store");
+
+    // Add one memory for conflicts
+    match store
+        .add_with_conflict("test", "Existing memory", None, false)
+        .unwrap()
+    {
+        vipune::AddResult::Added { .. } => {}
+        _ => panic!("Expected first add to succeed"),
+    }
+
+    // Mix of all outcomes
+    let items = vec![
+        BatchIngestItem::new("Existing memory".to_string()), // Conflict
+        BatchIngestItem::new("A completely new and unique memory about cloud infrastructure patterns".to_string()), // Added
+        BatchIngestItem::new("".to_string()), // Error
+        BatchIngestItem::new("Another distinct memory concerning database optimization strategies and query performance".to_string()), // Added
+    ];
+
+    let outcome = store
+        .batch_ingest("test", &items, IngestPolicy::ConflictAware)
+        .expect("Batch ingest should succeed");
+
+    // Verify summary matches manual count
+    assert_eq!(outcome.summary.total, 4);
+    assert_eq!(outcome.summary.added, 2);
+    assert_eq!(outcome.summary.conflicts, 1);
+    assert_eq!(outcome.summary.errors, 1);
 
     std::fs::remove_file(db_path).ok();
 }


### PR DESCRIPTION
Fixes #64\n\nAdds batch ingest API with per-item outcome tracking.