### PR TITLE
feat(#69): add shell installer and fix macOS tar extraction bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,13 @@ cargo-dist-version = "0.30.4"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = []
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Which actions to run on pull requests
 pr-run-mode = "upload"
+# Where to install the binary (default: ~/.cargo/bin/)
+install-path = "CARGO_HOME"
 
 [workspace.metadata.dist.github-custom-runners]
 aarch64-apple-darwin = "macos-14"

--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ Store semantic memories, search by meaning, and detect conflicts. Single binary 
 **Supported:** macOS ARM64, Linux x86_64, Linux ARM64  
 **Not supported:** Windows (due to ONNX Runtime compilation complexity)
 
-### Prerequisites
+### Quick install (macOS and Linux)
 
-For source installation:
-- Rust 1.70+ (install via https://rustup.rs)
-- System dependencies for ONNX Runtime:
-  - Linux: libgomp1, libc6
-  - macOS: None required
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh | sh
+```
+
+Install to a custom location:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh | sh -s -- --prefix=/usr/local
+```
+
+> The installer detects your platform, downloads the correct binary, and adds it to `~/.cargo/bin/` by default (already in PATH for Rust users). If you don't use Rust, restart your shell or run `export PATH="$HOME/.cargo/bin:$PATH"` to make vipune available. Use `--prefix` for system-wide installs.
 
 ### Pre-built binary
 
@@ -54,23 +60,9 @@ Download and extract:
 
 ```bash
 curl -sSfLO https://github.com/randomm/vipune/releases/latest/download/vipune-aarch64-apple-darwin.tar.xz
-tar xf vipune-aarch64-apple-darwin.tar.xz
-```
-
-Install to system PATH (requires sudo):
-
-```bash
+tar xf vipune-aarch64-apple-darwin.tar.xz --strip-components=1
 sudo mkdir -p /usr/local/bin && sudo mv vipune /usr/local/bin/
 ```
-
-Or install to user directory (no sudo):
-
-```bash
-mkdir -p ~/.local/bin && mv vipune ~/.local/bin/
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-> Add the `export` line to your `~/.zshrc` or `~/.bashrc` to make it permanent.
 
 **Linux x86_64**
 
@@ -78,12 +70,7 @@ Download and extract:
 
 ```bash
 curl -sSfLO https://github.com/randomm/vipune/releases/latest/download/vipune-x86_64-unknown-linux-gnu.tar.xz
-tar xf vipune-x86_64-unknown-linux-gnu.tar.xz
-```
-
-Install to system PATH:
-
-```bash
+tar xf vipune-x86_64-unknown-linux-gnu.tar.xz --strip-components=1
 sudo mkdir -p /usr/local/bin && sudo mv vipune /usr/local/bin/
 ```
 
@@ -93,16 +80,13 @@ Download and extract:
 
 ```bash
 curl -sSfLO https://github.com/randomm/vipune/releases/latest/download/vipune-aarch64-unknown-linux-gnu.tar.xz
-tar xf vipune-aarch64-unknown-linux-gnu.tar.xz
-```
-
-Install to system PATH:
-
-```bash
+tar xf vipune-aarch64-unknown-linux-gnu.tar.xz --strip-components=1
 sudo mkdir -p /usr/local/bin && sudo mv vipune /usr/local/bin/
 ```
 
 ### Build from source
+
+Requires the [Rust toolchain](https://rustup.rs) (1.85+). On Linux, you may also need `libgomp1` and `libc6`.
 
 **Latest release (recommended)**
 ```bash
@@ -132,14 +116,22 @@ export PATH="$(pwd)/target/release:$PATH"
 
 Remove the binary (whichever method you used to install):
 
+**Default install (curl or cargo):**
+```bash
+rm ~/.cargo/bin/vipune
+```
+
+**System-wide install:**
 ```bash
 sudo rm /usr/local/bin/vipune
 ```
 
+**Legacy user-directory install:**
 ```bash
 rm ~/.local/bin/vipune
 ```
 
+**Or via cargo:**
 ```bash
 cargo uninstall vipune
 ```

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ Store semantic memories, search by meaning, and detect conflicts. Single binary 
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh | sh
 ```
 
-Install to a custom location:
+> The installer detects your platform, downloads the correct binary, and adds it to `~/.cargo/bin/` by default. If you don't use Rust, restart your shell or run `export PATH="$HOME/.cargo/bin:$PATH"` to make vipune available. Use `--prefix=/usr/local` for system-wide installs.
 
+To verify the download before running, download the checksum file and check:
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh | sh -s -- --prefix=/usr/local
+curl -sSfLO https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh.sha256
+sha256sum -c vipune-installer.sh.sha256
+sh vipune-installer.sh
 ```
-
-> The installer detects your platform, downloads the correct binary, and adds it to `~/.cargo/bin/` by default (already in PATH for Rust users). If you don't use Rust, restart your shell or run `export PATH="$HOME/.cargo/bin:$PATH"` to make vipune available. Use `--prefix` for system-wide installs.
 
 ### Pre-built binary
 
@@ -114,27 +115,11 @@ export PATH="$(pwd)/target/release:$PATH"
 
 ### Uninstall
 
-Remove the binary (whichever method you used to install):
-
-**Default install (curl or cargo):**
 ```bash
-rm ~/.cargo/bin/vipune
+rm ~/.cargo/bin/vipune   # or: sudo rm /usr/local/bin/vipune
 ```
 
-**System-wide install:**
-```bash
-sudo rm /usr/local/bin/vipune
-```
-
-**Legacy user-directory install:**
-```bash
-rm ~/.local/bin/vipune
-```
-
-**Or via cargo:**
-```bash
-cargo uninstall vipune
-```
+Or via cargo: `cargo uninstall vipune`
 
 Optionally, clear all data:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,14 +5,11 @@ Get started with vipune in 5 minutes.
 ## Step 1: Install
 
 ```bash
-# Install from source
-cargo install --git https://github.com/randomm/vipune vipune
+# Quick install (macOS and Linux)
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases/latest/download/vipune-installer.sh | sh
 
-# Or build from source
-git clone https://github.com/randomm/vipune.git
-cd vipune
-cargo build --release
-cargo install --path .
+# Or install from source
+cargo install vipune
 ```
 
 **First run:** vipune will automatically download the ONNX model (~400MB) to `~/.vipune/models/`. This happens once and takes 30-60 seconds depending on your connection.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,8 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/randomm/vipune/releases
 cargo install vipune
 ```
 
+> For checksum verification before installing, see the [README](../README.md#installation).
+
 **First run:** vipune will automatically download the ONNX model (~400MB) to `~/.vipune/models/`. This happens once and takes 30-60 seconds depending on your connection.
 
 ## Step 2: Add Your First Memory


### PR DESCRIPTION
### Task Description
Fix the broken macOS install instructions and add a `curl | sh` one-liner installer for better user experience.

### Changes
- **Cargo.toml**: Enable cargo-dist shell installer (`installers = ["shell"]`) and set `install-path = "CARGO_HOME"`
- **README.md**: 
  - Add `curl | sh` one-liner as primary install method
  - Fix tar extraction bug with `--strip-components=1` on all platforms
  - Add PATH note for non-Rust users
  - Add prerequisites to Build from source section
  - Reorganize Uninstall section with labeled methods
- **docs/quickstart.md**: Update Step 1 to use curl|sh as primary method

### Quality Gates
- [x] cargo fmt --check passes
- [x] cargo clippy -- -D warnings passes
- [x] cargo test passes (154 tests)

Fixes #69