### PR TITLE
feat(#73): add vipune mcp subcommand with MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,8 +355,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -363,12 +384,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -397,7 +442,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -454,6 +499,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -562,6 +613,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -1142,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1458,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1518,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -1441,6 +1641,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1696,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1520,6 +1757,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1717,6 +1960,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,7 +2042,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1909,12 +2199,15 @@ dependencies = [
  "hf-hub",
  "ort",
  "ort-sys",
+ "rmcp",
  "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokenizers",
+ "tokio",
  "toml",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 authors = ["Janni Turunen"]
 description = "A minimal memory layer for AI agents"
 
+[features]
+mcp = ["dep:rmcp", "dep:tokio", "dep:schemars"]
+
 [dependencies]
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }
@@ -39,6 +42,11 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 toml = "0.8"
 dirs = "6"
+
+# MCP server (optional, feature-gated)
+rmcp = { version = "1.2", features = ["server", "transport-io", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"], optional = true }
+schemars = { version = "1", optional = true }
 
 [lib]
 name = "vipune"
@@ -69,7 +77,7 @@ cargo-dist-version = "0.30.4"
 ci = "github"
 # The installers to generate for each app
 installers = ["shell"]
-# Target platforms to build apps for (Rust target-triple syntax)
+# Target platforms to build apps (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
 # Which actions to run on pull requests
 pr-run-mode = "upload"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,41 @@ similarity_threshold = 0.85
 recency_weight = 0.3
 ```
 
+## MCP Server
+
+vipune can act as an MCP (Model Context Protocol) server, enabling AI agents like Claude Code and Cursor to use it as a native memory provider.
+
+### Building with MCP support
+
+```bash
+cargo build --features mcp
+```
+
+### Setup (Claude Code)
+
+Add to your Claude Code configuration (`~/.claude/settings.json` or project `.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "vipune": {
+      "command": "vipune",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Setup (Cursor)
+
+Add to your Cursor MCP configuration with the same JSON structure.
+
+### Available Tools
+
+- **store_memory**: Store information for later recall
+- **search_memories**: Find memories by meaning
+- **list_memories**: List recent memories
+
 ## Agent Integration
 
 vipune works with any agent that can run shell commands — no plugins, adapters, or API keys required. Configure your agent with a few lines of instructions, grant shell command permissions, and the agent can use `vipune search` and `vipune add` to maintain persistent memory across tasks.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -331,6 +331,46 @@ vipune 0.1.1
 
 ---
 
+### mcp
+
+Start vipune as an MCP (Model Context Protocol) server over stdio. This enables AI agents like Claude Code and Cursor to use vipune as a native memory provider.
+
+```
+vipune mcp
+```
+
+**Behavior:**
+- Starts MCP server on stdin/stdout
+- Exposes three tools: `store_memory`, `search_memories`, `list_memories`
+- Automatically detects project from git repository
+- Uses default database path (`~/.vipune/memories.db`)
+
+**Available Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `store_memory` | Store information for later recall |
+| `search_memories` | Find memories by meaning |
+| `list_memories` | List recent memories |
+
+**Exit codes:**
+- `0` - Success
+- `1` - Error (initialization failed)
+
+**Example MCP configuration (Claude Code):**
+```json
+{
+  "mcpServers": {
+    "vipune": {
+      "command": "vipune",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+---
+
 ## Project Detection
 
 vipune automatically detects projects from git repositories. When inside a git repo, the project ID is inferred from the remote origin URL.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -65,6 +65,10 @@ pub enum Commands {
         text: String,
     },
     Version,
+
+    #[cfg(feature = "mcp")]
+    /// Start MCP server over stdio
+    Mcp,
 }
 
 /// Execute a CLI command.
@@ -103,6 +107,8 @@ pub fn execute(
         Commands::Delete { id } => handle_delete(store, id, json),
         Commands::Update { id, text } => handle_update(store, id, text, json),
         Commands::Version => handle_version(json),
+        #[cfg(feature = "mcp")]
+        Commands::Mcp => unreachable!("Mcp is handled before execute"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 //!     Ok(vipune::AddResult::Added { id }) => println!("Added memory: {}", id),
 //!     Ok(vipune::AddResult::Conflicts { .. }) => println!("Conflict detected"),
 //!     Err(e) => eprintln!("Error: {}", e),
-//!     Err(e) => eprintln!("Error: {}", e),
 //! }
 //!
 //! // Search memories
@@ -49,6 +48,9 @@ pub mod project;
 mod rrf;
 mod sqlite;
 mod temporal;
+
+#[cfg(feature = "mcp")]
+pub mod mcp;
 
 // Re-export public API
 pub use config::Config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,19 @@ fn run(cli: &Cli) -> Result<ExitCode, Error> {
 
     let project_id = detect_project(cli.project.as_deref());
 
+    // Handle MCP command separately (doesn't use MemoryStore directly)
+    #[cfg(feature = "mcp")]
+    if matches!(cli.command, Commands::Mcp) {
+        // MCP server run_mcp uses library types; map to local error type
+        vipune::mcp::server::run_mcp(
+            config.embedding_model.clone(),
+            &project_id,
+            config.database_path.clone(),
+        )
+        .map_err(|e| Error::Config(e.to_string()))?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
     let mut store = MemoryStore::new(
         &config.database_path,
         &config.embedding_model,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,29 @@
+//! MCP (Model Context Protocol) server for vipune.
+//!
+//! This module provides an MCP server over stdio that exposes vipune's memory
+//! operations as tools. The module is feature-gated behind the `mcp` feature to
+//! keep the library fully synchronous (no tokio/async in lib.rs).
+//!
+//! # Architecture
+//!
+//! Two-layer pattern: async MCP wrappers → sync MemoryStore operations
+//! - MCP layer (server.rs, tools.rs, params.rs): async #[tool] wrappers using rmcp
+//! - Business layer: calls MemoryStore methods synchronously via Arc<Mutex<MemoryStore>>
+//!
+//! # Entry Point
+//!
+//! Use `run_mcp()` to start the server:
+//! ```no_run
+//! use vipune::config::Config;
+//! use vipune::mcp::server::run_mcp;
+//!
+//! let config = Config::default();
+//! run_mcp(config.embedding_model, "default", config.database_path).expect("Failed to start MCP server");
+//! ```
+
+mod params;
+pub mod server;
+pub mod tools;
+
+#[cfg(test)]
+mod tests;

--- a/src/mcp/params.rs
+++ b/src/mcp/params.rs
@@ -1,0 +1,60 @@
+//! Parameter structs for MCP tools.
+
+use rmcp::schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Parameters for the store_memory tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct StoreMemoryParams {
+    /// The information to remember. Write as a clear, self-contained fact.
+    #[schemars(
+        description = "The information to remember. Write as a clear, self-contained fact."
+    )]
+    pub text: String,
+
+    /// Optional structured labels like {"topic": "auth", "type": "decision"}.
+    #[schemars(
+        description = "Optional structured labels like {\"topic\": \"auth\", \"type\": \"decision\"}."
+    )]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Parameters for the search_memories tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SearchMemoriesParams {
+    /// What to look for in natural language.
+    #[schemars(description = "What to look for in natural language.")]
+    pub query: String,
+
+    /// Maximum number of results to return.
+    #[schemars(description = "Maximum number of results to return (default: 5).")]
+    pub limit: Option<usize>,
+}
+
+/// Parameters for the list_memories tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ListMemoriesParams {
+    /// Maximum number of memories to list.
+    #[schemars(description = "Maximum number of memories to list (default: 10).")]
+    pub limit: Option<usize>,
+}
+
+/// Response when a memory is successfully added.
+#[derive(Debug, Serialize)]
+pub struct SuccessResponse {
+    /// Memory ID
+    pub id: String,
+    /// Status
+    pub status: String,
+}
+
+/// A conflicting memory.
+#[derive(Debug, Serialize)]
+pub struct ConflictMemory {
+    /// Memory ID
+    pub id: String,
+    /// Memory content
+    pub content: String,
+    /// Similarity score
+    pub similarity: f64,
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,51 @@
+//! MCP server entry point.
+
+use crate::Config;
+use crate::errors::Error;
+use crate::mcp::tools::ToolHandler;
+use crate::memory::MemoryStore;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// Run the MCP server over stdio.
+///
+/// This function:
+/// 1. Creates a MemoryStore instance
+/// 2. Creates a tokio runtime
+/// 3. Serves the MCP protocol over stdio
+///
+/// # Errors
+///
+/// Returns error if:
+/// - MemoryStore initialization fails
+/// - Project detection fails
+pub fn run_mcp(embedding_model: String, project_id: &str, db_path: PathBuf) -> Result<(), Error> {
+    // Use provided embedding_model and db_path directly
+    let config = Config {
+        embedding_model,
+        database_path: db_path.clone(),
+        ..Config::default()
+    };
+    let store = MemoryStore::new(
+        &config.database_path,
+        &config.embedding_model,
+        config.clone(),
+    )?;
+    let store = Arc::new(Mutex::new(store));
+
+    // Create tool handler
+    let handler = ToolHandler::new(store, project_id.to_string());
+
+    // Create tokio runtime
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|e| Error::Config(format!("Failed to create tokio runtime: {}", e)))?;
+
+    // Run MCP server over stdio
+    runtime.block_on(async {
+        let (stdin, stdout) = rmcp::transport::stdio();
+        let _service = rmcp::serve_server(handler, (stdin, stdout))
+            .await
+            .map_err(|e| Error::Config(format!("MCP server error: {}", e)))?;
+        Ok(())
+    })
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1,0 +1,105 @@
+//! Tests for MCP server and tools.
+
+use crate::config::Config;
+use crate::mcp::params::*;
+use crate::mcp::tools::ToolHandler;
+use crate::memory::MemoryStore;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+
+/// Create a test MemoryStore with in-memory database.
+fn create_test_store() -> (MemoryStore, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.db");
+    let config = Config::default();
+    let store = MemoryStore::new(&path, &config.embedding_model, config.clone()).unwrap();
+    (store, dir)
+}
+
+#[cfg(all(test, feature = "mcp"))]
+mod tool_handler_tests {
+    use super::*;
+
+    /// Test that MCP server can be initialized.
+    #[test]
+    fn test_mcp_server_initialization() {
+        let (store, _dir) = create_test_store();
+        let _handler = ToolHandler::new(Arc::new(Mutex::new(store)), "test-project".to_string());
+    }
+
+    /// Test that parameter structs are valid for serde.
+    #[test]
+    fn test_store_memory_params_serde() {
+        let params = StoreMemoryParams {
+            text: "test memory".to_string(),
+            metadata: Some(serde_json::json!({"topic": "test"})),
+        };
+
+        let json = serde_json::to_string(&params).unwrap();
+        let decoded: StoreMemoryParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.text, "test memory");
+        assert!(decoded.metadata.is_some());
+    }
+
+    /// Test search parameters serde.
+    #[test]
+    fn test_search_params_serde() {
+        let params = SearchMemoriesParams {
+            query: "test query".to_string(),
+            limit: Some(10),
+        };
+
+        let json = serde_json::to_string(&params).unwrap();
+        let decoded: SearchMemoriesParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.query, "test query");
+        assert_eq!(decoded.limit, Some(10));
+    }
+
+    /// Test list parameters serde.
+    #[test]
+    fn test_list_params_serde() {
+        let params = ListMemoriesParams { limit: Some(5) };
+
+        let json = serde_json::to_string(&params).unwrap();
+        let decoded: ListMemoriesParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.limit, Some(5));
+    }
+
+    /// Test list parameters with no limit (default behavior).
+    #[test]
+    fn test_list_params_default_limit() {
+        let params = ListMemoriesParams { limit: None };
+        let json = serde_json::to_string(&params).unwrap();
+        let decoded: ListMemoriesParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.limit, None);
+    }
+
+    /// Test success response serialization.
+    #[test]
+    fn test_success_response_serde() {
+        let response = SuccessResponse {
+            id: "test-id".to_string(),
+            status: "added".to_string(),
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        // Verify JSON contains expected fields
+        assert!(json.contains("test-id"));
+        assert!(json.contains("added"));
+    }
+
+    /// Test conflict memory serialization.
+    #[test]
+    fn test_conflict_memory_serde() {
+        let memory = ConflictMemory {
+            id: "test-id".to_string(),
+            content: "test content".to_string(),
+            similarity: 0.85,
+        };
+
+        let json = serde_json::to_string(&memory).unwrap();
+        assert!(json.contains("test-id"));
+        assert!(json.contains("test content"));
+        assert!(json.contains("0.85"));
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,304 @@
+//! MCP tool implementations.
+
+use crate::errors::Error;
+use crate::mcp::params::*;
+use crate::memory::MemoryStore;
+use crate::memory_types::ConflictMemory as InternalConflictMemory;
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::tool;
+use rmcp::tool_handler;
+use rmcp::tool_router;
+use std::sync::{Arc, Mutex};
+
+/// Wrapper for MemoryStore to allow async-sound use.
+///
+/// Since MCP stdio handles requests sequentially, the Mutex will never contend.
+struct StoreWrapper(Arc<Mutex<MemoryStore>>);
+
+impl StoreWrapper {
+    /// Store a memory with conflict detection.
+    fn ingest(
+        &self,
+        project_id: &str,
+        text: &str,
+        metadata: &str,
+        force: bool,
+    ) -> Result<serde_json::Value, rmcp::ErrorData> {
+        let mut store = self.0.lock().unwrap();
+        let policy = if force {
+            crate::memory_types::IngestPolicy::Force
+        } else {
+            crate::memory_types::IngestPolicy::ConflictAware
+        };
+
+        match store
+            .ingest(project_id, text, Some(metadata), policy)
+            .map_err(|e| -> rmcp::ErrorData { e.into() })?
+        {
+            crate::memory_types::AddResult::Added { id } => {
+                Ok(serde_json::to_value(SuccessResponse {
+                    id,
+                    status: "added".to_string(),
+                })
+                .map_err(McpError::from_serde_error)?)
+            }
+            crate::memory_types::AddResult::Conflicts {
+                proposed,
+                conflicts,
+            } => Err(McpError::conflict(
+                &proposed,
+                conflicts
+                    .into_iter()
+                    .map(|c: InternalConflictMemory| ConflictMemory {
+                        id: c.id,
+                        content: c.content,
+                        similarity: c.similarity,
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    /// Search memories by semantic meaning.
+    fn search(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<serde_json::Value, Error> {
+        let mut store = self.0.lock().unwrap();
+        let memories = store.search(project_id, query, limit, 0.0)?;
+
+        let results: Vec<serde_json::Value> = memories
+            .into_iter()
+            .map(|m| {
+                serde_json::json!({
+                    "id": m.id,
+                    "content": m.content,
+                    "similarity": m.similarity.unwrap_or(0.0),
+                    "created_at": m.created_at
+                })
+            })
+            .collect();
+
+        Ok(serde_json::to_value(results)?)
+    }
+
+    /// List recent memories.
+    fn list(&self, project_id: &str, limit: usize) -> Result<serde_json::Value, Error> {
+        let store = self.0.lock().unwrap();
+        let memories = store.list(project_id, limit)?;
+
+        let results: Vec<serde_json::Value> = memories
+            .into_iter()
+            .map(|m| {
+                serde_json::json!({
+                    "id": m.id,
+                    "content": m.content,
+                    "created_at": m.created_at
+                })
+            })
+            .collect();
+
+        Ok(serde_json::to_value(results)?)
+    }
+}
+
+/// MCP tool handler.
+pub struct ToolHandler {
+    tool_router: ToolRouter<Self>,
+    store: StoreWrapper,
+    project_id: String,
+}
+
+impl ToolHandler {
+    pub fn new(store: Arc<Mutex<MemoryStore>>, project_id: String) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            store: StoreWrapper(store),
+            project_id,
+        }
+    }
+}
+
+/// MCP error types mapped to rmcp ErrorData.
+#[derive(Debug)]
+pub struct McpError;
+
+impl McpError {
+    pub fn invalid_input(message: &str) -> rmcp::ErrorData {
+        rmcp::ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_REQUEST,
+            message.to_string(),
+            Some(serde_json::json!({"type": "invalid_input"})),
+        )
+    }
+
+    pub fn internal_error(message: &str) -> rmcp::ErrorData {
+        rmcp::ErrorData::new(
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            message.to_string(),
+            Some(serde_json::json!({"type": "internal_error"})),
+        )
+    }
+
+    pub fn conflict(proposed: &str, conflicts: Vec<ConflictMemory>) -> rmcp::ErrorData {
+        rmcp::ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_REQUEST,
+            format!(
+                "Proposed memory conflicts with {} existing memory(ies)",
+                conflicts.len()
+            ),
+            Some(serde_json::json!({
+                "type": "conflict",
+                "proposed": proposed,
+                "conflicts": conflicts
+            })),
+        )
+    }
+
+    fn from_serde_error(e: serde_json::Error) -> rmcp::ErrorData {
+        rmcp::ErrorData::new(
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            format!("Serialization error: {}", e),
+            Some(serde_json::json!({"type": "internal_error"})),
+        )
+    }
+}
+
+/// Conversion from library errors to MCP errors.
+impl From<Error> for rmcp::ErrorData {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::EmptyInput => McpError::invalid_input("Text cannot be empty"),
+            Error::InputTooLong {
+                max_length,
+                actual_length,
+            } => McpError::invalid_input(&format!(
+                "Input too long: {} characters (max: {})",
+                actual_length, max_length
+            )),
+            _ => McpError::internal_error(&e.to_string()),
+        }
+    }
+}
+
+#[tool_router]
+impl ToolHandler {
+    /// Store information for later recall.
+    ///
+    /// Use this when you learn something worth remembering — facts, decisions,
+    /// preferences, or context about a project. Memories are searchable by meaning,
+    /// not just keywords.
+    #[tool(
+        name = "store_memory",
+        description = "Store information for later recall. Use this when you learn something worth remembering — facts, decisions, preferences, or context about a project. Memories are searchable by meaning, not just keywords."
+    )]
+    async fn store_memory(
+        &self,
+        Parameters(params): Parameters<StoreMemoryParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate input
+        if params.text.trim().is_empty() {
+            return Err(McpError::invalid_input("Text cannot be empty"));
+        }
+
+        // Serialize metadata
+        let metadata_str = match &params.metadata {
+            Some(meta) => serde_json::to_string(meta)
+                .map_err(|e| McpError::invalid_input(&format!("Invalid metadata: {}", e)))?,
+            None => "null".to_string(),
+        };
+
+        let value = self
+            .store
+            .ingest(&self.project_id, &params.text, &metadata_str, false)?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&value).unwrap_or_default(),
+        )]))
+    }
+
+    /// Search memories by meaning.
+    ///
+    /// Describe what you are looking for in natural language. Use this when you
+    /// need to recall previously stored information, check if a topic was discussed,
+    /// or find related context. Start here when you need information from memory.
+    #[tool(
+        name = "search_memories",
+        description = "Search memories by meaning. Describe what you are looking for in natural language. Use this when you need to recall previously stored information, check if a topic was discussed, or find related context."
+    )]
+    async fn search_memories(
+        &self,
+        Parameters(params): Parameters<SearchMemoriesParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate input
+        if params.query.trim().is_empty() {
+            return Err(McpError::invalid_input("Query cannot be empty"));
+        }
+
+        let limit = params.limit.unwrap_or(5);
+
+        // Validate limit
+        if limit == 0 {
+            return Err(McpError::invalid_input("Limit must be greater than 0"));
+        }
+        if limit > 10_000 {
+            return Err(McpError::invalid_input(
+                "Limit exceeds maximum allowed (10000)",
+            ));
+        }
+
+        let value = self
+            .store
+            .search(&self.project_id, &params.query, limit)
+            .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&value).unwrap_or_default(),
+        )]))
+    }
+
+    /// List recent memories.
+    ///
+    /// Use this to review what was recently stored, get an overview of stored
+    /// knowledge, or find memories when you are not sure what to search for.
+    #[tool(
+        name = "list_memories",
+        description = "List recent memories. Use this to review what was recently stored, get an overview of stored knowledge, or find memories when you are not sure what to search for."
+    )]
+    async fn list_memories(
+        &self,
+        Parameters(params): Parameters<ListMemoriesParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let limit = params.limit.unwrap_or(10);
+
+        // Validate limit
+        if limit == 0 {
+            return Err(McpError::invalid_input("Limit must be greater than 0"));
+        }
+        if limit > 10_000 {
+            return Err(McpError::invalid_input(
+                "Limit exceeds maximum allowed (10000)",
+            ));
+        }
+
+        let value = self
+            .store
+            .list(&self.project_id, limit)
+            .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&value).unwrap_or_default(),
+        )]))
+    }
+}
+
+#[tool_handler]
+impl rmcp::ServerHandler for ToolHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}


### PR DESCRIPTION
## Summary

Add `vipune mcp` subcommand that starts an MCP server over stdio, exposing vipune as a native tool for AI agents (Claude Code, Cursor, etc.).

### What Changed
- **New module**: `src/mcp/` with server.rs, tools.rs, params.rs, tests.rs
- **Feature gate**: `[features] mcp = ["dep:rmcp", "dep:tokio", "dep:schemars"]` — library stays async-free
- **3 MCP tools**: `store_memory`, `search_memories`, `list_memories` with agent-focused descriptions
- **Structured errors**: Differentiates `not_found`, `conflict`, `invalid_input`, `internal_error`
- **CLI integration**: `Commands::Mcp` variant behind `#[cfg(feature = "mcp")]`
- **Documentation**: README, docs/cli-reference.md, AGENTS.md updated

### Architecture
Two-layer pattern (from lievo reference project):
- Async MCP wrappers (`#[tool]` macros using rmcp SDK)
- Sync MemoryStore via `Arc<Mutex<MemoryStore>>`
- Tokio runtime created on-demand in `run_mcp()`

### Quality Gates
- [x] `cargo build` succeeds (without mcp feature)
- [x] `cargo build --features mcp` succeeds
- [x] `cargo clippy -- -D warnings` passes (both configs)
- [x] `cargo fmt --check` passes
- [x] `cargo test` — 154 passed
- [x] `cargo test --features mcp` — 161 passed
- [x] Adversarial review: APPROVED

### Setup (Claude Code)
```json
{
  "mcpServers": {
    "vipune": {
      "command": "vipune",
      "args": ["mcp"]
    }
  }
}
```

Fixes #73