### PR TITLE
fix(#80): keep MCP server alive until client disconnects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ path = "src/main.rs"
 
 [dev-dependencies]
 tempfile = "3.13"
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [profile.release]
 strip = true

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 /// Run the MCP server over stdio.
 ///
-/// This function:
+/// This function blocks until the client disconnects. It:
 /// 1. Creates a MemoryStore instance
 /// 2. Creates a tokio runtime
 /// 3. Serves the MCP protocol over stdio
@@ -45,9 +45,13 @@ pub fn run_mcp(embedding_model: String, project_id: &str, db_path: PathBuf) -> R
     // Run MCP server over stdio
     runtime.block_on(async {
         let (stdin, stdout) = rmcp::transport::stdio();
-        let _service = rmcp::serve_server(handler, (stdin, stdout))
+        let service = rmcp::serve_server(handler, (stdin, stdout))
             .await
             .map_err(|e| Error::Config(format!("MCP server error: {}", e)))?;
+        service
+            .waiting()
+            .await
+            .map_err(|e| Error::Config(format!("MCP server task error: {}", e)))?;
         Ok(())
     })
 }

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -102,4 +102,34 @@ mod tool_handler_tests {
         assert!(json.contains("test content"));
         assert!(json.contains("0.85"));
     }
+
+    /// Tests ToolHandler data path: ingest, search, and list operations through StoreWrapper.
+    #[tokio::test]
+    async fn test_store_and_search_integration() {
+        let (store, _dir) = create_test_store();
+        let store = Arc::new(Mutex::new(store));
+        let wrapper = super::super::tools::StoreWrapper::new(store.clone());
+        let project_id = "test-project";
+
+        // Ingest a memory
+        let result = wrapper.ingest(project_id, "rust is awesome", "null", false);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        let json_str = serde_json::to_string(&value).unwrap();
+        assert!(json_str.contains("added"));
+
+        // Search for it
+        let search_result = wrapper.search(project_id, "rust programming", 5);
+        assert!(search_result.is_ok());
+        let search_value = search_result.unwrap();
+        let search_str = serde_json::to_string(&search_value).unwrap();
+        assert!(search_str.contains("rust is awesome"));
+
+        // List it
+        let list_result = wrapper.list(project_id, 10);
+        assert!(list_result.is_ok());
+        let list_value = list_result.unwrap();
+        let list_str = serde_json::to_string(&list_value).unwrap();
+        assert!(list_str.contains("rust is awesome"));
+    }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -15,11 +15,17 @@ use std::sync::{Arc, Mutex};
 /// Wrapper for MemoryStore to allow async-sound use.
 ///
 /// Since MCP stdio handles requests sequentially, the Mutex will never contend.
-struct StoreWrapper(Arc<Mutex<MemoryStore>>);
+pub(crate) struct StoreWrapper(Arc<Mutex<MemoryStore>>);
 
 impl StoreWrapper {
+    /// Create a new StoreWrapper from a shared MemoryStore.
+    #[allow(dead_code)]
+    pub(crate) fn new(store: Arc<Mutex<MemoryStore>>) -> Self {
+        Self(store)
+    }
+
     /// Store a memory with conflict detection.
-    fn ingest(
+    pub(crate) fn ingest(
         &self,
         project_id: &str,
         text: &str,
@@ -62,7 +68,7 @@ impl StoreWrapper {
     }
 
     /// Search memories by semantic meaning.
-    fn search(
+    pub(crate) fn search(
         &self,
         project_id: &str,
         query: &str,
@@ -87,7 +93,7 @@ impl StoreWrapper {
     }
 
     /// List recent memories.
-    fn list(&self, project_id: &str, limit: usize) -> Result<serde_json::Value, Error> {
+    pub(crate) fn list(&self, project_id: &str, limit: usize) -> Result<serde_json::Value, Error> {
         let store = self.0.lock().unwrap();
         let memories = store.list(project_id, limit)?;
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -19,7 +19,7 @@ pub(crate) struct StoreWrapper(Arc<Mutex<MemoryStore>>);
 
 impl StoreWrapper {
     /// Create a new StoreWrapper from a shared MemoryStore.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Used in cfg(test) builds
     pub(crate) fn new(store: Arc<Mutex<MemoryStore>>) -> Self {
         Self(store)
     }


### PR DESCRIPTION
### Root Cause

`rmcp::serve_server().await` only handles the MCP initialization handshake and returns a `RunningService` handle. The actual message serving (tools/list, store_memory, etc.) runs as a background tokio task. The previous code dropped the handle immediately, cancelling the background task before any tool calls could be served.

### Fix

Add `service.waiting().await` to keep `block_on` alive until the client disconnects:

```rust
let service = rmcp::serve_server(handler, (stdin, stdout))
    .await
    .map_err(|e| Error::Config(format!("MCP server error: {}", e)))?;
service.waiting().await
    .map_err(|e| Error::Config(format!("MCP server task error: {}", e)))?;
```

This matches the pattern used by reference MCP server implementations with rmcp v1.2.

### Changes
- `src/mcp/server.rs`: Add `service.waiting().await` — core lifecycle fix
- `src/mcp/tools.rs`: Make `StoreWrapper` and methods `pub(crate)` for test access
- `src/mcp/tests.rs`: Add `#[tokio::test]` exercising ingest/search/list data path
- `Cargo.toml`: Add `tokio` to `[dev-dependencies]` for `#[tokio::test]`

### Quality Gates
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (162 passed)
- `cargo test --no-default-features` ✅ (154 passed)
- `cargo clippy --no-default-features -- -D warnings` ✅

Fixes #80
Part of #72