### PR TITLE
feat(#83): pin embedding model revision and expose public constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ Optionally, clear all data:
 rm -rf ~/.vipune ~/.config/vipune
 ```
 
+## Air-gapped / Offline Usage
+
+vipune downloads the embedding model from HuggingFace Hub on first run. The model is pinned to a specific SHA to ensure reproducibility:
+
+- **Model ID**: `BAAI/bge-small-en-v1.5`
+- **Pinned revision SHA**: `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a`
+
+For air-gapped environments, pre-fetch the model before going offline:
+
+```bash
+# Install huggingface-cli first if you don't have it
+pip install huggingface_hub
+
+# Download the pinned model to the cache directory
+huggingface-cli download BAAI/bge-small-en-v1.5 \
+  --revision 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a \
+  --cache-dir ~/.cache/huggingface/hub
+```
+
+The model will be cached in the HF Hub cache layout at `~/.cache/huggingface/hub/` and vipune will use it without network access. You can verify the cache before going offline:
+
+```bash
+ls ~/.cache/huggingface/hub/models--BAAI--bge-small-en-v1.5/
+```
+
+**Note**: When upgrading vipune, the pinned revision may change. Check the release notes and re-download the new revision if the SHA has changed.
+
+**Library consumers**: The constants `vipune::EMBED_MODEL_ID` and `vipune::EMBED_MODEL_REVISION` are exported for tracking the pinned model version programmatically.
+
 ## Quick Start
 
 Add a memory:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,7 @@ mod tests_utils;
 #[cfg(test)]
 use tests_utils::{ENV_MUTEX, cleanup_env_vars};
 
+use crate::embedding::EMBED_MODEL_ID;
 use crate::errors::Error;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -65,7 +66,7 @@ impl Default for Config {
 
         Self {
             database_path: vipune_dir.join("memories.db"),
-            embedding_model: "BAAI/bge-small-en-v1.5".to_string(),
+            embedding_model: EMBED_MODEL_ID.to_string(),
             model_cache: vipune_dir.join("models"),
             similarity_threshold: 0.85,
             recency_weight: 0.3,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -204,4 +204,14 @@ mod tests {
         assert!(config.model_cache.ends_with(".vipune/models"));
         assert_eq!(config.similarity_threshold, 0.85);
     }
+
+    #[test]
+    fn test_default_model_matches_embed_constant() {
+        let config = Config::default();
+        assert_eq!(
+            config.embedding_model,
+            crate::embedding::EMBED_MODEL_ID,
+            "Config::default() model must match EMBED_MODEL_ID — update both when changing the default model"
+        );
+    }
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -2,7 +2,7 @@
 //!
 //! Uses bge-small-en-v1.5 model (384 dimensions) with mean pooling and L2 normalization.
 
-use hf_hub::api::sync::Api;
+use hf_hub::{Repo, RepoType, api::sync::Api};
 use ort::inputs;
 use ort::session::Session;
 use ort::session::builder::GraphOptimizationLevel;
@@ -16,6 +16,12 @@ use tokenizers::TruncationParams;
 ///
 /// All generated embeddings are 384-dimensional vectors.
 pub const EMBEDDING_DIMS: usize = 384;
+
+/// HuggingFace model ID for the embedding model.
+pub const EMBED_MODEL_ID: &str = "BAAI/bge-small-en-v1.5";
+
+/// Pinned revision SHA for the embedding model to ensure reproducibility.
+pub const EMBED_MODEL_REVISION: &str = "5c38ec7c405ec4b44b94cc5a9bb96e735b38267a";
 
 /// ONNX embedding engine for synchronous text-to-vector conversion.
 ///
@@ -34,21 +40,51 @@ pub struct EmbeddingEngine {
 }
 
 impl EmbeddingEngine {
-    /// Load model from cache or download on first use.
+    /// Creates a new embedding engine with the specified model.
     ///
-    /// # Sync API Choice
+    /// When `model_id` is the default model (`EMBED_MODEL_ID`), the pinned revision
+    /// `EMBED_MODEL_REVISION` is used to ensure reproducibility. Custom model IDs
+    /// fall back to the `main` branch.
     ///
-    /// Uses `hf_hub::api::sync::Api` with ureq feature for blocking I/O.
-    /// This approach is fully synchronous, matching vipune's no-async policy.
     /// Files are cached locally in HF Hub cache, only downloaded once.
     pub fn new(model_id: &str) -> Result<Self, Error> {
         let api = Api::new()?;
-        let repo = api.model(model_id.to_string());
+
+        // Use pinned revision for default model, "main" for custom models
+        let revision = if model_id == EMBED_MODEL_ID {
+            EMBED_MODEL_REVISION.to_string()
+        } else {
+            "main".to_string()
+        };
+
+        // Capture the actual model_id and revision for the error message
+        let err_model_id = model_id.to_string();
+        let err_revision = revision.clone();
+
+        let repo = api.repo(Repo::with_revision(
+            model_id.to_string(),
+            RepoType::Model,
+            revision,
+        ));
+
+        // Helper function for error messaging
+        let wrap_download_err = move |e: hf_hub::api::sync::ApiError| {
+            let revision_hint = if err_model_id == EMBED_MODEL_ID {
+                format!(" --revision {}", err_revision)
+            } else {
+                String::new()
+            };
+            Error::Config(format!(
+                "Failed to download embedding model '{}': {}.\n\nIf running in an air-gapped environment, pre-fetch the model before going offline:\n  huggingface-cli download {}{} --cache-dir ~/.cache/huggingface/hub",
+                err_model_id, e, err_model_id, revision_hint
+            ))
+        };
 
         let model_path = repo
             .get("onnx/model.onnx")
-            .or_else(|_| repo.get("model.onnx"))?;
-        let tokenizer_path = repo.get("tokenizer.json")?;
+            .or_else(|_| repo.get("model.onnx"))
+            .map_err(&wrap_download_err)?;
+        let tokenizer_path = repo.get("tokenizer.json").map_err(&wrap_download_err)?;
 
         let mut tokenizer = Tokenizer::from_file(tokenizer_path)?;
         tokenizer
@@ -196,6 +232,13 @@ mod tests {
     #[test]
     fn test_embedding_dimensions() {
         assert_eq!(EMBEDDING_DIMS, 384);
+    }
+
+    #[test]
+    fn test_embed_model_constants() {
+        assert_eq!(EMBED_MODEL_ID, "BAAI/bge-small-en-v1.5");
+        assert_eq!(EMBED_MODEL_REVISION.len(), 40); // SHA-1 is 40 hex chars
+        assert!(EMBED_MODEL_REVISION.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod mcp;
 
 // Re-export public API
 pub use config::Config;
-pub use embedding::{EMBEDDING_DIMS, EmbeddingEngine};
+pub use embedding::{EMBED_MODEL_ID, EMBED_MODEL_REVISION, EMBEDDING_DIMS, EmbeddingEngine};
 pub use errors::Error;
 pub use memory::MemoryStore;
 pub use memory::store::{MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};


### PR DESCRIPTION
## Summary

Pins the HuggingFace model revision in the `hf_hub` call to a specific SHA, eliminating drift risk when HF moves `main`. Exposes the pinned revision as a public constant for downstream consumers.

## Changes

- `pub const EMBED_MODEL_ID: &str` and `pub const EMBED_MODEL_REVISION: &str` added to `src/embedding.rs`
- Both re-exported at crate root: `vipune::EMBED_MODEL_ID`, `vipune::EMBED_MODEL_REVISION`
- `hf_hub` call updated to `Repo::with_revision()` — default model gets pinned SHA, custom models fall back to `"main"`
- `Config::default()` uses `EMBED_MODEL_ID` constant (single source of truth)
- Download failures emit actionable air-gapped pre-fetch instructions with correct `--cache-dir` flag
- README: new "Air-gapped / Offline Usage" section documents pre-fetch workflow and verification

## Migration

Existing network-connected users: one-time model re-download on first run after upgrade (new SHA). Subsequent runs are fully cached.

Air-gapped users: must pre-fetch the pinned revision before upgrading:
```bash
huggingface-cli download BAAI/bge-small-en-v1.5 \
  --revision 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a \
  --cache-dir ~/.cache/huggingface/hub
```

Fixes #83