### PR TITLE
fix(#90): fail-fast on over-length content instead of silent truncation

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,7 +4,7 @@ use crate::errors::Error;
 use crate::memory::MemoryStore;
 use crate::memory_types::{AddResult, IngestPolicy};
 use crate::output::*;
-use crate::{config, temporal};
+use crate::{config, embedding::EmbeddingEngine, temporal};
 use std::process::ExitCode;
 
 struct SearchContext {
@@ -17,6 +17,10 @@ struct SearchContext {
 /// Commands supported by vipune CLI.
 #[derive(clap::Subcommand)]
 pub enum Commands {
+    Validate {
+        /// Text to validate for embedding
+        text: String,
+    },
     Add {
         /// Memory text content
         text: String,
@@ -80,6 +84,7 @@ pub fn execute(
     json: bool,
 ) -> Result<ExitCode, Error> {
     match command {
+        Commands::Validate { text } => handle_validate(text, &config.embedding_model, json),
         Commands::Add {
             text,
             metadata,
@@ -110,6 +115,34 @@ pub fn execute(
         #[cfg(feature = "mcp")]
         Commands::Mcp => unreachable!("Mcp is handled before execute"),
     }
+}
+
+fn handle_validate(text: &str, model_id: &str, json: bool) -> Result<ExitCode, Error> {
+    let engine = EmbeddingEngine::new(model_id)?;
+    let token_count = engine.token_count(text)?;
+
+    if token_count > crate::embedding::MAX_EMBEDDING_TOKENS {
+        return Err(Error::ContentTooLong {
+            token_count,
+            max_tokens: crate::embedding::MAX_EMBEDDING_TOKENS,
+        });
+    }
+
+    if json {
+        print_json(&ValidateResponse {
+            token_count,
+            max_tokens: crate::embedding::MAX_EMBEDDING_TOKENS,
+            within_limit: true,
+        });
+    } else {
+        println!(
+            "Token count: {}/{} — within limit",
+            token_count,
+            crate::embedding::MAX_EMBEDDING_TOKENS
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
 }
 
 fn handle_add(
@@ -306,4 +339,25 @@ fn handle_version(json: bool) -> Result<ExitCode, Error> {
         println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
     }
     Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_short_text() {
+        let short_text = "hello world";
+        let result = handle_validate(short_text, "not-a-real-model-should-fail", false);
+        // Should fail because model doesn't exist, not because of token count
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_long_text() {
+        let long_text = "a".repeat(1000);
+        let result = handle_validate(&long_text, "not-a-real-model-should-fail", false);
+        // Should fail because model doesn't exist, not because of token count
+        assert!(result.is_err());
+    }
 }

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -17,6 +17,11 @@ use tokenizers::TruncationParams;
 /// All generated embeddings are 384-dimensional vectors.
 pub const EMBEDDING_DIMS: usize = 384;
 
+/// Maximum number of tokens allowed for embedding.
+///
+/// Content exceeding this limit will be rejected instead of silently truncated.
+pub const MAX_EMBEDDING_TOKENS: usize = 512;
+
 /// HuggingFace model ID for the embedding model.
 pub const EMBED_MODEL_ID: &str = "BAAI/bge-small-en-v1.5";
 
@@ -111,6 +116,15 @@ impl EmbeddingEngine {
         })
     }
 
+    /// Count tokens in text without generating an embedding.
+    ///
+    /// Returns the number of tokens that would be generated for the given text.
+    /// This is used for validation before embedding operations.
+    pub fn token_count(&self, text: &str) -> Result<usize, Error> {
+        let encoding = self.tokenizer.encode(text, true)?;
+        Ok(encoding.get_ids().len())
+    }
+
     /// Generate embedding for a single text.
     ///
     /// Returns exactly 384-dimensional f32 vector, L2-normalized.
@@ -120,12 +134,22 @@ impl EmbeddingEngine {
     /// Empty strings return a zero vector. This provides graceful handling
     /// without requiring error recovery from callers.
     ///
-    /// # Token Truncation
+    /// # Token Limit
     ///
-    /// Texts exceeding 512 tokens are silently truncated via tokenizer truncation.
+    /// Texts exceeding 512 tokens are rejected with a ContentTooLong error instead
+    /// of being silently truncated.
     pub fn embed(&mut self, text: &str) -> Result<Vec<f32>, Error> {
         if text.is_empty() {
             return Ok(vec![0.0f32; EMBEDDING_DIMS]);
+        }
+
+        // Validate token count BEFORE embedding
+        let token_count = self.token_count(text)?;
+        if token_count > MAX_EMBEDDING_TOKENS {
+            return Err(Error::ContentTooLong {
+                token_count,
+                max_tokens: MAX_EMBEDDING_TOKENS,
+            });
         }
 
         let encoding = self.tokenizer.encode(text, true)?;
@@ -307,15 +331,153 @@ mod tests {
 
     #[ignore]
     #[test]
-    fn test_integration_long_text_truncation() {
+    fn test_integration_long_text_rejection() {
         let mut engine = EmbeddingEngine::new("BAAI/bge-small-en-v1.5").expect("load model");
 
+        // Create text long enough to exceed 512 tokens
         let long_text = "This is a sentence. ".repeat(100);
-        let embedding = engine.embed(&long_text).expect("embed long text");
+        let encoding = engine
+            .tokenizer
+            .encode(long_text.as_str(), true)
+            .expect("encode long text");
+        let token_count = encoding.get_ids().len();
 
+        assert!(token_count > 512, "Test setup: need >512 tokens");
+
+        // Should error with ContentTooLong
+        let result = engine.embed(&long_text);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            Error::ContentTooLong {
+                token_count: tc,
+                max_tokens,
+            } => {
+                assert_eq!(tc, token_count);
+                assert_eq!(max_tokens, MAX_EMBEDDING_TOKENS);
+            }
+            _ => panic!("Expected ContentTooLong error"),
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn test_integration_boundary_511_tokens() {
+        let mut engine = EmbeddingEngine::new("BAAI/bge-small-en-v1.5").expect("load model");
+
+        // Construct text with exactly 511 tokens
+        let mut text = String::new();
+        let mut token_count = 0;
+        while token_count < 511 {
+            let test_word = "word";
+            let encoding = engine
+                .tokenizer
+                .encode(format!("{} ", test_word).as_str(), true)
+                .unwrap();
+            let word_tokens = encoding.get_ids().len();
+
+            if token_count + word_tokens > 511 {
+                break;
+            }
+            text.push_str(test_word);
+            text.push_str(" ");
+            token_count += word_tokens;
+        }
+
+        assert_eq!(token_count, 511);
+
+        // Should succeed
+        let embedding = engine.embed(&text).expect("embed 511-token text");
         assert_eq!(embedding.len(), 384);
 
         let norm: f32 = embedding.iter().map(|&x| x * x).sum::<f32>().sqrt();
         assert!((norm - 1.0).abs() < 0.01);
+    }
+
+    #[ignore]
+    #[test]
+    fn test_integration_boundary_512_tokens() {
+        let mut engine = EmbeddingEngine::new("BAAI/bge-small-en-v1.5").expect("load model");
+
+        // Construct text with exactly 512 tokens
+        let mut text = String::new();
+        let mut token_count = 0;
+        while token_count < 512 {
+            let test_word = "word";
+            let encoding = engine
+                .tokenizer
+                .encode(format!("{} ", test_word).as_str(), true)
+                .unwrap();
+            let word_tokens = encoding.get_ids().len();
+
+            if token_count + word_tokens > 512 {
+                break;
+            }
+            text.push_str(test_word);
+            text.push_str(" ");
+            token_count += word_tokens;
+        }
+
+        assert_eq!(token_count, 512);
+
+        // Should succeed
+        let embedding = engine.embed(&text).expect("embed 512-token text");
+        assert_eq!(embedding.len(), 384);
+
+        let norm: f32 = embedding.iter().map(|&x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 0.01);
+    }
+
+    #[ignore]
+    #[test]
+    fn test_integration_boundary_513_tokens() {
+        let mut engine = EmbeddingEngine::new("BAAI/bge-small-en-v1.5").expect("load model");
+
+        // Construct text with exactly 513 tokens
+        let mut text = String::new();
+        let mut token_count = 0;
+        while token_count < 513 {
+            let test_word = "word";
+            let encoding = engine
+                .tokenizer
+                .encode(format!("{} ", test_word).as_str(), true)
+                .unwrap();
+            let word_tokens = encoding.get_ids().len();
+
+            if token_count + word_tokens > 513 {
+                break;
+            }
+            text.push_str(test_word);
+            text.push_str(" ");
+            token_count += word_tokens;
+        }
+
+        assert_eq!(token_count, 513);
+
+        // Should fail with ContentTooLong
+        let result = engine.embed(&text);
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            Error::ContentTooLong {
+                token_count: tc,
+                max_tokens,
+            } => {
+                assert_eq!(tc, 513);
+                assert_eq!(max_tokens, MAX_EMBEDDING_TOKENS);
+            }
+            _ => panic!("Expected ContentTooLong error"),
+        }
+    }
+
+    #[ignore]
+    #[test]
+    fn test_token_count_method() {
+        let engine = EmbeddingEngine::new("BAAI/bge-small-en-v1.5").expect("load model");
+
+        let text = "hello world";
+        let token_count = engine.token_count(text).expect("count tokens");
+        assert!(token_count > 0);
+        assert!(token_count <= 512);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,6 +56,13 @@ pub enum Error {
         actual_length: usize,
     },
 
+    /// Content exceeds maximum embedding token limit.
+    #[error("content exceeds {max_tokens}-token embedding limit (measured: {token_count} tokens)")]
+    ContentTooLong {
+        token_count: usize,
+        max_tokens: usize,
+    },
+
     /// Invalid timestamp in database record.
     #[error("Invalid timestamp format: {timestamp} ({error})")]
     InvalidTimestamp { timestamp: String, error: String },

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,13 @@ fn main() -> ExitCode {
     match run(&cli) {
         Ok(exit_code) => exit_code,
         Err(error) => {
+            // Map ContentTooLong errors to exit code 3
+            let exit_code = if matches!(error, Error::ContentTooLong { .. }) {
+                ExitCode::from(3)
+            } else {
+                ExitCode::from(1)
+            };
+
             if cli.json {
                 print_json(&ErrorResponse {
                     error: error.to_string(),
@@ -53,7 +60,7 @@ fn main() -> ExitCode {
             } else {
                 eprintln!("Error: {}", error);
             }
-            ExitCode::from(1)
+            exit_code
         }
     }
 }
@@ -186,6 +193,15 @@ mod tests {
     fn test_cli_parse_version() {
         let cli = Cli::parse_from(["vipune", "version"]);
         matches!(cli.command, Commands::Version);
+    }
+
+    #[test]
+    fn test_cli_parse_validate() {
+        let cli = Cli::parse_from(["vipune", "validate", "test text"]);
+        matches!(
+            cli.command,
+            Commands::Validate { text } if text == "test text"
+        );
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -192,6 +192,13 @@ impl From<Error> for rmcp::ErrorData {
             Error::InvalidTimestamp { timestamp, error } => {
                 McpError::invalid_input(&format!("Invalid timestamp '{}': {}", timestamp, error))
             }
+            Error::ContentTooLong {
+                token_count,
+                max_tokens,
+            } => McpError::invalid_input(&format!(
+                "Content exceeds {}-token embedding limit (measured: {} tokens)",
+                max_tokens, token_count
+            )),
             // Not found → INVALID_REQUEST with not_found type
             Error::NotFound(msg) => rmcp::ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_REQUEST,

--- a/src/output.rs
+++ b/src/output.rs
@@ -113,6 +113,17 @@ pub struct ConflictMemoryResponse {
     pub similarity: f64,
 }
 
+/// Response for token validation.
+#[derive(Serialize)]
+pub struct ValidateResponse {
+    /// Token count of the validated text.
+    pub token_count: usize,
+    /// Maximum allowed tokens for embedding.
+    pub max_tokens: usize,
+    /// Whether the text is within the embedding limit.
+    pub within_limit: bool,
+}
+
 /// Serialize a value as formatted JSON and print to stdout.
 ///
 /// Exits with status 1 if serialization fails.


### PR DESCRIPTION
## Summary

- Replaces silent 512-token truncation in embedding with explicit rejection (exit code 3)
- Adds `ContentTooLong` error variant with measured token count in message
- New `vipune validate <text>` command for pre-flight token count checking
- MCP `store_memory` returns structured error for over-length input
- Boundary tests for 511/512/513 token limits

### Breaking change

Content that previously embedded silently (with degraded quality due to truncation) now fails with exit code 3. Callers should handle this by summarizing externally before storing.

Fixes #90