### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-27
+
+
 ## [0.2.6] - 2026-04-18
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,7 +2191,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vipune"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vipune"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vipune`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `vipune` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Memory.memory_type in /tmp/.tmp1FcANY/vipune/src/sqlite/mod.rs:52
  field Memory.status in /tmp/.tmp1FcANY/vipune/src/sqlite/mod.rs:55
  field Memory.superseded_by in /tmp/.tmp1FcANY/vipune/src/sqlite/mod.rs:58

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ContentTooLong in /tmp/.tmp1FcANY/vipune/src/errors.rs:61
  variant Error:ContentTooLong in /tmp/.tmp1FcANY/vipune/src/errors.rs:61

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vipune::memory::MemoryStore::add_with_conflict now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:66
  vipune::memory::MemoryStore::list now takes 4 parameters instead of 2, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:224
  vipune::memory::MemoryStore::update now takes 3 parameters instead of 2, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:256
  vipune::memory::MemoryStore::list_since now takes 5 parameters instead of 3, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:330
  vipune::memory::MemoryStore::search now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/search.rs:43
  vipune::memory::MemoryStore::search_hybrid now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/search.rs:123
  vipune::MemoryStore::add_with_conflict now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:66
  vipune::MemoryStore::list now takes 4 parameters instead of 2, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:224
  vipune::MemoryStore::update now takes 3 parameters instead of 2, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:256
  vipune::MemoryStore::list_since now takes 5 parameters instead of 3, in /tmp/.tmp1FcANY/vipune/src/memory/crud.rs:330
  vipune::MemoryStore::search now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/search.rs:43
  vipune::MemoryStore::search_hybrid now takes 6 parameters instead of 4, in /tmp/.tmp1FcANY/vipune/src/memory/search.rs:123
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).