### PR TITLE
feat(#89): add memory type, lifecycle status, and atomic supersede

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::Error;
 use crate::memory::MemoryStore;
+use crate::memory::lifecycle::{MemoryStatus, MemoryType};
 use crate::memory_types::{AddResult, IngestPolicy};
 use crate::output::*;
 use crate::{config, embedding::EmbeddingEngine, temporal};
@@ -12,6 +13,9 @@ struct SearchContext {
     limit: usize,
     recency: Option<f64>,
     hybrid: bool,
+    memory_type: Option<String>,
+    status: Option<String>,
+    include_candidates: bool,
 }
 
 /// Commands supported by vipune CLI.
@@ -32,6 +36,18 @@ pub enum Commands {
         /// Bypass conflict detection and store the memory unconditionally.
         #[arg(long)]
         force: bool,
+
+        /// Memory type (fact, preference, procedure, guard, observation)
+        #[arg(long, default_value = "fact")]
+        memory_type: String,
+
+        /// Memory status (active, candidate)
+        #[arg(long, default_value = "active")]
+        status: String,
+
+        /// Supersede an existing memory (atomic replacement)
+        #[arg(long)]
+        supersedes: Option<String>,
     },
     Search {
         /// Search query text
@@ -48,6 +64,18 @@ pub enum Commands {
         /// Use hybrid search (semantic + BM25 with RRF fusion)
         #[arg(long)]
         hybrid: bool,
+
+        /// Filter by memory type (comma-separated)
+        #[arg(long)]
+        memory_type: Option<String>,
+
+        /// Filter by status (default: active)
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Include candidate memories in results
+        #[arg(long)]
+        include_candidates: bool,
     },
     Get {
         /// Memory ID
@@ -57,6 +85,18 @@ pub enum Commands {
         /// Maximum number of results (default: 10)
         #[arg(short = 'l', long, default_value = "10")]
         limit: usize,
+
+        /// Filter by memory type (comma-separated)
+        #[arg(long)]
+        memory_type: Option<String>,
+
+        /// Filter by status (default: active)
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Include candidate memories in results
+        #[arg(long)]
+        include_candidates: bool,
     },
     Delete {
         /// Memory ID
@@ -73,6 +113,14 @@ pub enum Commands {
         /// Optional JSON metadata (replaces existing metadata)
         #[arg(short = 'm', long)]
         metadata: Option<String>,
+
+        /// Update memory type
+        #[arg(long)]
+        memory_type: Option<String>,
+
+        /// Update memory status
+        #[arg(long)]
+        status: Option<String>,
     },
     Version,
 
@@ -95,12 +143,28 @@ pub fn execute(
             text,
             metadata,
             force,
-        } => handle_add(store, &project_id, text, metadata.as_deref(), *force, json),
+            memory_type,
+            status,
+            supersedes,
+        } => handle_add(
+            store,
+            &project_id,
+            text,
+            metadata.as_deref(),
+            *force,
+            memory_type,
+            status,
+            supersedes.as_deref(),
+            json,
+        ),
         Commands::Search {
             query,
             limit,
             recency,
             hybrid,
+            memory_type,
+            status,
+            include_candidates,
         } => handle_search(
             store,
             &project_id,
@@ -109,16 +173,44 @@ pub fn execute(
                 limit: *limit,
                 recency: *recency,
                 hybrid: *hybrid,
+                memory_type: memory_type.clone(),
+                status: status.clone(),
+                include_candidates: *include_candidates,
             },
             config,
             json,
         ),
         Commands::Get { id } => handle_get(store, id, json),
-        Commands::List { limit } => handle_list(store, &project_id, *limit, json),
+        Commands::List {
+            limit,
+            memory_type,
+            status,
+            include_candidates,
+        } => handle_list(
+            store,
+            &project_id,
+            *limit,
+            memory_type.as_deref(),
+            status.as_deref(),
+            *include_candidates,
+            json,
+        ),
         Commands::Delete { id } => handle_delete(store, id, json),
-        Commands::Update { id, text, metadata } => {
-            handle_update(store, id, text.as_deref(), metadata.as_deref(), json)
-        }
+        Commands::Update {
+            id,
+            text,
+            metadata,
+            memory_type,
+            status,
+        } => handle_update(
+            store,
+            id,
+            text.as_deref(),
+            metadata.as_deref(),
+            memory_type.as_deref(),
+            status.as_deref(),
+            json,
+        ),
         Commands::Version => handle_version(json),
         #[cfg(feature = "mcp")]
         Commands::Mcp => unreachable!("Mcp is handled before execute"),
@@ -153,21 +245,74 @@ fn handle_validate(text: &str, model_id: &str, json: bool) -> Result<ExitCode, E
     Ok(ExitCode::SUCCESS)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_add(
     store: &mut MemoryStore,
     project_id: &str,
     text: &str,
     metadata: Option<&str>,
     force: bool,
+    memory_type: &str,
+    status: &str,
+    supersedes: Option<&str>,
     json: bool,
 ) -> Result<ExitCode, Error> {
+    // Validate memory_type
+    let _ = MemoryType::from_str(memory_type)?;
+
+    // Validate status
+    let status_val = MemoryStatus::from_str(status)?;
+    if !status_val.is_valid_for_insert() {
+        return Err(Error::InvalidInput(format!(
+            "Status '{}' is not valid for new memory insertion. Must be 'active' or 'candidate'.",
+            status
+        )));
+    }
+
+    // Check mutually exclusive flags
+    if supersedes.is_some() && force {
+        return Err(Error::InvalidInput(
+            "Cannot use both --supersedes and --force flags together".to_string(),
+        ));
+    }
+
+    // If supersedes is provided, use supersede flow
+    if let Some(old_id) = supersedes {
+        // Use mock embedding if embedder is not loaded (test mode)
+        let embedding = if store.embedder.is_none() {
+            crate::memory::crud::mock_embedding_for_content(text)
+        } else {
+            store.embedder()?.embed(text)?
+        };
+
+        let metadata_str = metadata.map(|s| s.to_string());
+        let new_id = store.db.supersede(
+            project_id,
+            text,
+            &embedding,
+            metadata_str.as_deref(),
+            memory_type,
+            old_id,
+        )?;
+
+        if json {
+            print_json(&AddResponse {
+                status: "superseded".to_string(),
+                id: new_id,
+            });
+        } else {
+            println!("Superseded memory {} with new memory", old_id);
+        }
+        return Ok(ExitCode::SUCCESS);
+    }
+
     let policy = if force {
         IngestPolicy::Force
     } else {
         IngestPolicy::ConflictAware
     };
 
-    match store.ingest(project_id, text, metadata, policy)? {
+    match store.ingest_with_type_status(project_id, text, metadata, policy, memory_type, status)? {
         AddResult::Added { id } => {
             if json {
                 print_json(&AddResponse {
@@ -223,10 +368,47 @@ fn handle_search(
 ) -> Result<ExitCode, Error> {
     let recency_weight = opts.recency.unwrap_or(config.recency_weight);
     temporal::validate_recency_weight(recency_weight)?;
-    let memories = if opts.hybrid {
-        store.search_hybrid(project_id, &opts.query, opts.limit, recency_weight)?
+
+    // Build filter params from CLI flags
+    let type_vec: Option<Vec<String>> = opts
+        .memory_type
+        .as_ref()
+        .map(|t| t.split(',').map(|s| s.trim().to_string()).collect());
+    let type_strs: Option<Vec<&str>> = type_vec
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    let type_slice: Option<&[&str]> = type_strs.as_deref();
+
+    let status_vec: Option<Vec<String>> = if opts.include_candidates {
+        Some(vec!["active".to_string(), "candidate".to_string()])
     } else {
-        store.search(project_id, &opts.query, opts.limit, recency_weight)?
+        opts.status
+            .as_ref()
+            .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
+    };
+    let status_strs: Option<Vec<&str>> = status_vec
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    let status_slice: Option<&[&str]> = status_strs.as_deref();
+
+    let memories = if opts.hybrid {
+        store.search_hybrid(
+            project_id,
+            &opts.query,
+            opts.limit,
+            recency_weight,
+            type_slice,
+            status_slice,
+        )?
+    } else {
+        store.search(
+            project_id,
+            &opts.query,
+            opts.limit,
+            recency_weight,
+            type_slice,
+            status_slice,
+        )?
     };
     if json {
         let results: Vec<SearchResultItem> = memories
@@ -281,9 +463,30 @@ fn handle_list(
     store: &mut MemoryStore,
     project_id: &str,
     limit: usize,
+    memory_type: Option<&str>,
+    status: Option<&str>,
+    include_candidates: bool,
     json: bool,
 ) -> Result<ExitCode, Error> {
-    let memories = store.list(project_id, limit)?;
+    // Build filter params from CLI flags
+    let type_vec: Option<Vec<String>> =
+        memory_type.map(|t| t.split(',').map(|s| s.trim().to_string()).collect());
+    let type_strs: Option<Vec<&str>> = type_vec
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    let type_slice: Option<&[&str]> = type_strs.as_deref();
+
+    let status_vec: Option<Vec<String>> = if include_candidates {
+        Some(vec!["active".to_string(), "candidate".to_string()])
+    } else {
+        status.map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
+    };
+    let status_strs: Option<Vec<&str>> = status_vec
+        .as_ref()
+        .map(|v| v.iter().map(|s| s.as_str()).collect());
+    let status_slice: Option<&[&str]> = status_strs.as_deref();
+
+    let memories = store.list(project_id, limit, type_slice, status_slice)?;
     if json {
         let items: Vec<ListItem> = memories
             .into_iter()
@@ -324,6 +527,8 @@ fn handle_update(
     id: &str,
     text: Option<&str>,
     metadata: Option<&str>,
+    _memory_type: Option<&str>,
+    _status: Option<&str>,
     json: bool,
 ) -> Result<ExitCode, Error> {
     if text.is_none() && metadata.is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! let project_id = detect_project(None);
 //!
 //! // Add a memory with conflict detection
-//! let result = store.add_with_conflict(&project_id, "Alice works at Microsoft", None, false);
+//! let result = store.add_with_conflict(&project_id, "Alice works at Microsoft", None, false, "fact", "active");
 //! match result {
 //!     Ok(vipune::AddResult::Added { id }) => println!("Added memory: {}", id),
 //!     Ok(vipune::AddResult::Conflicts { .. }) => println!("Conflict detected"),
@@ -28,7 +28,7 @@
 //! }
 //!
 //! // Search memories
-//! let results = store.search(&project_id, "where does alice work", 10, 0.0);
+//! let results = store.search(&project_id, "where does alice work", 10, 0.0, None, None);
 //! for memory in results.unwrap() {
 //!     println!("{:.2}: {}", memory.similarity.unwrap_or(0.0), memory.content);
 //! }
@@ -57,6 +57,7 @@ pub use config::Config;
 pub use embedding::{EMBED_MODEL_ID, EMBED_MODEL_REVISION, EMBEDDING_DIMS, EmbeddingEngine};
 pub use errors::Error;
 pub use memory::MemoryStore;
+pub use memory::lifecycle::{MemoryStatus, MemoryType};
 pub use memory::store::{MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT};
 pub use memory_types::{
     AddResult, BatchIngestItemResult, BatchIngestResult, ConflictMemory, IngestPolicy,

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,16 +186,16 @@ mod tests {
         let cli = Cli::parse_from(["vipune", "update", "memory-id", "--text", "new content"]);
         matches!(
             cli.command,
-            Commands::Update { id, text, metadata }
-            if id == "memory-id" && text == Some("new content".to_string()) && metadata.is_none()
+            Commands::Update { id, text, metadata, memory_type, status }
+            if id == "memory-id" && text == Some("new content".to_string()) && metadata.is_none() && memory_type.is_none() && status.is_none()
         );
 
         // Update with metadata only
         let cli = Cli::parse_from(["vipune", "update", "memory-id", "-m", r#"{"tag": "new"}"#]);
         matches!(
             cli.command,
-            Commands::Update { id, text, metadata }
-            if id == "memory-id" && text.is_none() && metadata == Some(r#"{"tag": "new"}"#.to_string())
+            Commands::Update { id, text, metadata, memory_type, status }
+            if id == "memory-id" && text.is_none() && metadata == Some(r#"{"tag": "new"}"#.to_string()) && memory_type.is_none() && status.is_none()
         );
 
         // Update with both
@@ -210,8 +210,8 @@ mod tests {
         ]);
         matches!(
             cli.command,
-            Commands::Update { id, text, metadata }
-            if id == "memory-id" && text == Some("new".to_string()) && metadata == Some(r#"{"key":"val"}"#.to_string())
+            Commands::Update { id, text, metadata, memory_type, status }
+            if id == "memory-id" && text == Some("new".to_string()) && metadata == Some(r#"{"key":"val"}"#.to_string()) && memory_type.is_none() && status.is_none()
         );
     }
 

--- a/src/mcp/params.rs
+++ b/src/mcp/params.rs
@@ -29,6 +29,14 @@ pub struct SearchMemoriesParams {
     /// Maximum number of results to return.
     #[schemars(description = "Maximum number of results to return (default: 5).")]
     pub limit: Option<usize>,
+
+    /// Filter by memory types.
+    #[schemars(description = "Filter by memory types (e.g., fact, preference, procedure).")]
+    pub memory_types: Option<Vec<String>>,
+
+    /// Filter by statuses.
+    #[schemars(description = "Filter by statuses (e.g., active, candidate).")]
+    pub statuses: Option<Vec<String>>,
 }
 
 /// Parameters for the list_memories tool.
@@ -37,6 +45,14 @@ pub struct ListMemoriesParams {
     /// Maximum number of memories to list.
     #[schemars(description = "Maximum number of memories to list (default: 10).")]
     pub limit: Option<usize>,
+
+    /// Filter by memory types.
+    #[schemars(description = "Filter by memory types (e.g., fact, preference, procedure).")]
+    pub memory_types: Option<Vec<String>>,
+
+    /// Filter by statuses.
+    #[schemars(description = "Filter by statuses (e.g., active, candidate).")]
+    pub statuses: Option<Vec<String>>,
 }
 
 /// Response when a memory is successfully added.

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -47,28 +47,42 @@ mod tool_handler_tests {
         let params = SearchMemoriesParams {
             query: "test query".to_string(),
             limit: Some(10),
+            memory_types: None,
+            statuses: None,
         };
 
         let json = serde_json::to_string(&params).unwrap();
         let decoded: SearchMemoriesParams = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.query, "test query");
         assert_eq!(decoded.limit, Some(10));
+        assert!(decoded.memory_types.is_none());
+        assert!(decoded.statuses.is_none());
     }
 
     /// Test list parameters serde.
     #[test]
     fn test_list_params_serde() {
-        let params = ListMemoriesParams { limit: Some(5) };
+        let params = ListMemoriesParams {
+            limit: Some(5),
+            memory_types: None,
+            statuses: None,
+        };
 
         let json = serde_json::to_string(&params).unwrap();
         let decoded: ListMemoriesParams = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.limit, Some(5));
+        assert!(decoded.memory_types.is_none());
+        assert!(decoded.statuses.is_none());
     }
 
     /// Test list parameters with no limit (default behavior).
     #[test]
     fn test_list_params_default_limit() {
-        let params = ListMemoriesParams { limit: None };
+        let params = ListMemoriesParams {
+            limit: None,
+            memory_types: None,
+            statuses: None,
+        };
         let json = serde_json::to_string(&params).unwrap();
         let decoded: ListMemoriesParams = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.limit, None);
@@ -119,14 +133,14 @@ mod tool_handler_tests {
         assert!(json_str.contains("added"));
 
         // Search for it
-        let search_result = wrapper.search(project_id, "rust programming", 5);
+        let search_result = wrapper.search(project_id, "rust programming", 5, None, None);
         assert!(search_result.is_ok());
         let search_value = search_result.unwrap();
         let search_str = serde_json::to_string(&search_value).unwrap();
         assert!(search_str.contains("rust is awesome"));
 
         // List it
-        let list_result = wrapper.list(project_id, 10);
+        let list_result = wrapper.list(project_id, 10, None, None);
         assert!(list_result.is_ok());
         let list_value = list_result.unwrap();
         let list_str = serde_json::to_string(&list_value).unwrap();
@@ -148,7 +162,7 @@ mod tool_handler_tests {
         assert!(result.is_ok());
 
         // Search for it
-        let search_result = wrapper.search(project_id, "rust", 5);
+        let search_result = wrapper.search(project_id, "rust", 5, None, None);
         assert!(search_result.is_ok());
         let search_value = search_result.unwrap();
 
@@ -202,7 +216,7 @@ mod tool_handler_tests {
         assert!(result.is_ok());
 
         // Search for it
-        let search_result = wrapper.search(project_id, "simple", 5);
+        let search_result = wrapper.search(project_id, "simple", 5, None, None);
         assert!(search_result.is_ok());
         let search_value = search_result.unwrap();
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -73,9 +73,11 @@ impl StoreWrapper {
         project_id: &str,
         query: &str,
         limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<serde_json::Value, Error> {
         let mut store = self.0.lock().unwrap();
-        let memories = store.search(project_id, query, limit, 0.0)?;
+        let memories = store.search(project_id, query, limit, 0.0, memory_types, statuses)?;
 
         let results: Vec<serde_json::Value> = memories
             .into_iter()
@@ -105,9 +107,15 @@ impl StoreWrapper {
     }
 
     /// List recent memories.
-    pub(crate) fn list(&self, project_id: &str, limit: usize) -> Result<serde_json::Value, Error> {
+    pub(crate) fn list(
+        &self,
+        project_id: &str,
+        limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
+    ) -> Result<serde_json::Value, Error> {
         let store = self.0.lock().unwrap();
-        let memories = store.list(project_id, limit)?;
+        let memories = store.list(project_id, limit, memory_types, statuses)?;
 
         let results: Vec<serde_json::Value> = memories
             .into_iter()
@@ -301,9 +309,28 @@ impl ToolHandler {
             ));
         }
 
+        // Convert filter params
+        let type_strs: Option<Vec<&str>> = params
+            .memory_types
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let type_slice: Option<&[&str]> = type_strs.as_deref();
+
+        let status_strs: Option<Vec<&str>> = params
+            .statuses
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let status_slice: Option<&[&str]> = status_strs.as_deref();
+
         let value = self
             .store
-            .search(&self.project_id, &params.query, limit)
+            .search(
+                &self.project_id,
+                &params.query,
+                limit,
+                type_slice,
+                status_slice,
+            )
             .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?;
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -335,9 +362,22 @@ impl ToolHandler {
             ));
         }
 
+        // Convert filter params
+        let type_strs: Option<Vec<&str>> = params
+            .memory_types
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let type_slice: Option<&[&str]> = type_strs.as_deref();
+
+        let status_strs: Option<Vec<&str>> = params
+            .statuses
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let status_slice: Option<&[&str]> = status_strs.as_deref();
+
         let value = self
             .store
-            .list(&self.project_id, limit)
+            .list(&self.project_id, limit, type_slice, status_slice)
             .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?;
 
         Ok(CallToolResult::success(vec![Content::text(

--- a/src/memory/batch_tests.rs
+++ b/src/memory/batch_tests.rs
@@ -38,8 +38,15 @@ fn test_batch_ingest_mixed_outcomes() {
     // Use the same mock embedding function that add_with_conflict uses
     // so exact duplicates produce identical embeddings (deterministic)
     let embedding = super::crud::mock_embedding_for_content("Alice works at Microsoft");
-    db.insert("test-project", "Alice works at Microsoft", &embedding, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "Alice works at Microsoft",
+        &embedding,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
     let mut store = MemoryStore::from_db(db, config);
 
@@ -120,8 +127,15 @@ fn test_batch_ingest_deterministic_index_mapping() {
     // Use the same mock embedding function that add_with_conflict uses
     // so exact duplicates produce identical embeddings (deterministic)
     let embedding = super::crud::mock_embedding_for_content("conflict with item 1");
-    db.insert("test-project", "conflict with item 1", &embedding, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "conflict with item 1",
+        &embedding,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
     let mut store = MemoryStore::from_db(db, config);
 
@@ -180,8 +194,15 @@ fn test_batch_ingest_policy_force() {
     // Pre-populate with conflicting content
     // Use the same mock embedding function for consistency
     let embedding = super::crud::mock_embedding_for_content("Alice works at Microsoft");
-    db.insert("test-project", "Alice works at Microsoft", &embedding, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "Alice works at Microsoft",
+        &embedding,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
     let mut store = MemoryStore::from_db(db, config);
 

--- a/src/memory/crud.rs
+++ b/src/memory/crud.rs
@@ -48,6 +48,8 @@ impl MemoryStore {
     /// * `content` - Text content to store (1 to 100,000 characters)
     /// * `metadata` - Optional JSON metadata string
     /// * `force` - If true, bypass conflict detection and add regardless
+    /// * `memory_type` - Memory type string (fact, preference, procedure, guard, observation)
+    /// * `status` - Memory status string (active, candidate)
     ///
     /// # Returns
     ///
@@ -67,6 +69,8 @@ impl MemoryStore {
         content: &str,
         metadata: Option<&str>,
         force: bool,
+        memory_type: &str,
+        status: &str,
     ) -> Result<AddResult, Error> {
         Self::validate_input_length(content)?;
 
@@ -78,7 +82,14 @@ impl MemoryStore {
         };
 
         if force {
-            let id = self.db.insert(project_id, content, &embedding, metadata)?;
+            let id = self.db.insert(
+                project_id,
+                content,
+                &embedding,
+                metadata,
+                memory_type,
+                status,
+            )?;
             return Ok(AddResult::Added { id });
         }
 
@@ -95,7 +106,14 @@ impl MemoryStore {
             .collect();
 
         if conflicts.is_empty() {
-            let id = self.db.insert(project_id, content, &embedding, metadata)?;
+            let id = self.db.insert(
+                project_id,
+                content,
+                &embedding,
+                metadata,
+                memory_type,
+                status,
+            )?;
             Ok(AddResult::Added { id })
         } else {
             Ok(AddResult::Conflicts {
@@ -146,6 +164,7 @@ impl MemoryStore {
     ///     AddResult::Conflicts { .. } => unreachable!(),
     /// };
     /// ```
+    #[allow(dead_code)] // Library API: available for consumers
     pub fn ingest(
         &mut self,
         project_id: &str,
@@ -153,11 +172,27 @@ impl MemoryStore {
         metadata: Option<&str>,
         policy: IngestPolicy,
     ) -> Result<AddResult, Error> {
+        self.ingest_with_type_status(project_id, content, metadata, policy, "fact", "active")
+    }
+
+    /// Ingest with explicit memory type and status.
+    #[must_use = "handle the error or results may be lost"]
+    pub fn ingest_with_type_status(
+        &mut self,
+        project_id: &str,
+        content: &str,
+        metadata: Option<&str>,
+        policy: IngestPolicy,
+        memory_type: &str,
+        status: &str,
+    ) -> Result<AddResult, Error> {
         match policy {
             IngestPolicy::ConflictAware => {
-                self.add_with_conflict(project_id, content, metadata, false)
+                self.add_with_conflict(project_id, content, metadata, false, memory_type, status)
             }
-            IngestPolicy::Force => self.add_with_conflict(project_id, content, metadata, true),
+            IngestPolicy::Force => {
+                self.add_with_conflict(project_id, content, metadata, true, memory_type, status)
+            }
         }
     }
 
@@ -178,16 +213,24 @@ impl MemoryStore {
     ///
     /// * `project_id` - Project identifier
     /// * `limit` - Maximum number of results to return
+    /// * `memory_types` - Optional filter by memory types
+    /// * `statuses` - Optional filter by memory statuses
     ///
     /// # Errors
     ///
     /// Returns error if:
     /// - Limit is 0
     /// - Limit exceeds MAX_SEARCH_LIMIT
-    pub fn list(&self, project_id: &str, limit: usize) -> Result<Vec<Memory>, Error> {
+    pub fn list(
+        &self,
+        project_id: &str,
+        limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
+    ) -> Result<Vec<Memory>, Error> {
         use super::store::validate_limit;
         validate_limit(limit)?;
-        Ok(self.db.list(project_id, limit)?)
+        Ok(self.db.list(project_id, limit, memory_types, statuses)?)
     }
 
     #[must_use = "handle the error or results may be lost"]
@@ -267,6 +310,8 @@ impl MemoryStore {
     /// * `project_id` - Project identifier
     /// * `since_timestamp` - RFC3339-formatted timestamp (exclusive lower bound)
     /// * `limit` - Maximum number of results to return
+    /// * `memory_types` - Optional filter by memory types
+    /// * `statuses` - Optional filter by memory statuses
     ///
     /// # Errors
     ///
@@ -280,17 +325,21 @@ impl MemoryStore {
     /// ```ignore
     /// use chrono::Utc;
     /// let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
-    /// let recent = store.list_since("project", &one_hour_ago, 10)?;
+    /// let recent = store.list_since("project", &one_hour_ago, 10, None, None)?;
     /// ```
     pub fn list_since(
         &self,
         project_id: &str,
         since_timestamp: &str,
         limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<Vec<Memory>, Error> {
         use super::store::validate_limit;
         validate_limit(limit)?;
-        Ok(self.db.list_since(project_id, since_timestamp, limit)?)
+        Ok(self
+            .db
+            .list_since(project_id, since_timestamp, limit, memory_types, statuses)?)
     }
 
     #[allow(dead_code)] // Public API for library consumers (e.g., kide)
@@ -390,7 +439,9 @@ impl MemoryStore {
                 Err(e) => BatchIngestItemResult::Error {
                     message: format!("{}", e),
                 },
-                Ok(()) => match self.add_with_conflict(project_id, content, metadata, force) {
+                Ok(()) => match self
+                    .add_with_conflict(project_id, content, metadata, force, "fact", "active")
+                {
                     Ok(AddResult::Added { id }) => BatchIngestItemResult::Added { id },
                     Ok(AddResult::Conflicts {
                         proposed,

--- a/src/memory/lifecycle.rs
+++ b/src/memory/lifecycle.rs
@@ -1,0 +1,169 @@
+//! Memory type and lifecycle status definitions.
+//!
+//! Provides validation and constants for memory types and lifecycle status values.
+
+use crate::errors::Error;
+
+/// Valid memory types.
+///
+/// Each type serves a specific role in memory retrieval and routing:
+/// - `fact`: General factual information (default)
+/// - `preference`: User or system preferences
+/// - `procedure`: Step-by-step instructions or workflows
+/// - `guard`: Safety rules or constraints that should be checked before actions
+/// - `observation`: Temporary or observational data that may become stale
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MemoryType {
+    #[default]
+    Fact,
+    Preference,
+    Procedure,
+    Guard,
+    Observation,
+}
+
+impl MemoryType {
+    /// Get the string representation of the memory type.
+    #[allow(dead_code)] // Public API for library consumers
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MemoryType::Fact => "fact",
+            MemoryType::Preference => "preference",
+            MemoryType::Procedure => "procedure",
+            MemoryType::Guard => "guard",
+            MemoryType::Observation => "observation",
+        }
+    }
+
+    /// Parse a string into a MemoryType.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidInput` if the string is not a valid memory type.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        match s.to_lowercase().as_str() {
+            "fact" => Ok(MemoryType::Fact),
+            "preference" => Ok(MemoryType::Preference),
+            "procedure" => Ok(MemoryType::Procedure),
+            "guard" => Ok(MemoryType::Guard),
+            "observation" => Ok(MemoryType::Observation),
+            _ => Err(Error::InvalidInput(format!(
+                "Invalid memory type '{}'. Must be one of: fact, preference, procedure, guard, observation",
+                s
+            ))),
+        }
+    }
+}
+
+/// Memory lifecycle status.
+///
+/// Tracks the state of a memory through its lifecycle:
+/// - `active`: Currently in use and returned by default in searches (default)
+/// - `candidate`: Proposed memory awaiting activation (not returned by default)
+/// - `superseded`: Replaced by a newer memory (not returned by default)
+/// - `deprecated`: Marked as obsolete or incorrect (not returned by default)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MemoryStatus {
+    #[default]
+    Active,
+    Candidate,
+    Superseded,
+    Deprecated,
+}
+
+impl MemoryStatus {
+    /// Get the string representation of the memory status.
+    #[allow(dead_code)] // Public API for library consumers
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MemoryStatus::Active => "active",
+            MemoryStatus::Candidate => "candidate",
+            MemoryStatus::Superseded => "superseded",
+            MemoryStatus::Deprecated => "deprecated",
+        }
+    }
+
+    /// Parse a string into a MemoryStatus.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidInput` if the string is not a valid memory status.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        match s.to_lowercase().as_str() {
+            "active" => Ok(MemoryStatus::Active),
+            "candidate" => Ok(MemoryStatus::Candidate),
+            "superseded" => Ok(MemoryStatus::Superseded),
+            "deprecated" => Ok(MemoryStatus::Deprecated),
+            _ => Err(Error::InvalidInput(format!(
+                "Invalid memory status '{}'. Must be one of: active, candidate, superseded, deprecated",
+                s
+            ))),
+        }
+    }
+
+    /// Check if this status is allowed for new memory insertion.
+    pub fn is_valid_for_insert(self) -> bool {
+        matches!(self, MemoryStatus::Active | MemoryStatus::Candidate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_memory_type_roundtrip() {
+        for (s, expected) in [
+            ("fact", MemoryType::Fact),
+            ("preference", MemoryType::Preference),
+            ("procedure", MemoryType::Procedure),
+            ("guard", MemoryType::Guard),
+            ("observation", MemoryType::Observation),
+        ] {
+            let parsed = MemoryType::from_str(s).unwrap();
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn test_memory_type_case_insensitive() {
+        assert_eq!(MemoryType::from_str("FACT").unwrap(), MemoryType::Fact);
+        assert_eq!(MemoryType::from_str("Guard").unwrap(), MemoryType::Guard);
+    }
+
+    #[test]
+    fn test_memory_type_invalid() {
+        assert!(MemoryType::from_str("invalid").is_err());
+        assert!(MemoryType::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_memory_status_roundtrip() {
+        for (s, expected) in [
+            ("active", MemoryStatus::Active),
+            ("candidate", MemoryStatus::Candidate),
+            ("superseded", MemoryStatus::Superseded),
+            ("deprecated", MemoryStatus::Deprecated),
+        ] {
+            let parsed = MemoryStatus::from_str(s).unwrap();
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn test_memory_status_invalid() {
+        assert!(MemoryStatus::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_is_valid_for_insert() {
+        assert!(MemoryStatus::Active.is_valid_for_insert());
+        assert!(MemoryStatus::Candidate.is_valid_for_insert());
+        assert!(!MemoryStatus::Superseded.is_valid_for_insert());
+        assert!(!MemoryStatus::Deprecated.is_valid_for_insert());
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3,11 +3,13 @@
 //! Provides a high-level API for storing, searching, and retrieving memories
 //! with automatic embedding generation via the ONNX model.
 
-mod crud;
+pub(crate) mod crud;
 mod search;
 
 // pub(crate): module internals hidden; public items re-exported explicitly via lib.rs
 pub(crate) mod store;
+
+pub mod lifecycle;
 
 pub use store::MemoryStore;
 

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -24,6 +24,8 @@ impl MemoryStore {
     /// * `query` - Search query text (1 to 100,000 characters)
     /// * `limit` - Maximum number of results to return
     /// * `recency_weight` - Weight for temporal decay (0.0 = pure semantic, 1.0 = max recency)
+    /// * `memory_types` - Optional filter by memory types
+    /// * `statuses` - Optional filter by memory statuses
     ///
     /// # Returns
     ///
@@ -44,6 +46,8 @@ impl MemoryStore {
         query: &str,
         limit: usize,
         recency_weight: f64,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<Vec<Memory>, Error> {
         // Validate limit to prevent resource exhaustion
         validate_limit(limit)?;
@@ -54,7 +58,9 @@ impl MemoryStore {
 
         validate_recency_weight(recency_weight).map_err(Error::Validation)?;
         let embedding = self.embedder()?.embed(query)?;
-        let mut memories = self.db.search(project_id, &embedding, limit)?;
+        let mut memories = self
+            .db
+            .search(project_id, &embedding, limit, memory_types, statuses)?;
 
         if recency_weight > 0.0 {
             let decay_config = DecayConfig::new()?;
@@ -98,6 +104,8 @@ impl MemoryStore {
     /// * `query` - Search query text (1 to 100,000 characters)
     /// * `limit` - Maximum number of results to return
     /// * `recency_weight` - Weight for temporal decay (0.0 = pure score, 1.0 = max recency)
+    /// * `memory_types` - Optional filter by memory types
+    /// * `statuses` - Optional filter by memory statuses
     ///
     /// # Returns
     ///
@@ -118,6 +126,8 @@ impl MemoryStore {
         query: &str,
         limit: usize,
         recency_weight: f64,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<Vec<Memory>, Error> {
         // Validate query before processing
         let query = query.trim();
@@ -135,7 +145,13 @@ impl MemoryStore {
         let candidate_pool = limit.saturating_mul(10).clamp(50, MAX_CANDIDATE_POOL);
 
         // 3. Run semantic search
-        let semantic_results = self.db.search(project_id, &embedding, candidate_pool)?;
+        let semantic_results = self.db.search(
+            project_id,
+            &embedding,
+            candidate_pool,
+            memory_types,
+            statuses,
+        )?;
 
         // 4. Run BM25 search
         let bm25_results = self.db.search_bm25(query, project_id, candidate_pool)?;

--- a/src/memory/tests/crud.rs
+++ b/src/memory/tests/crud.rs
@@ -22,7 +22,14 @@ fn test_add_and_get() {
     let db = Database::open(&path).unwrap();
     let embedding = vec![0.5f32; 384];
     let id = db
-        .insert("test-project", "test content", &embedding, Some("metadata"))
+        .insert(
+            "test-project",
+            "test content",
+            &embedding,
+            Some("metadata"),
+            "fact",
+            "active",
+        )
         .unwrap();
 
     let memory = db.get(&id).unwrap().unwrap();
@@ -44,7 +51,14 @@ fn test_update_memory() {
     let embedding_new = vec![0.8f32; 384];
 
     let id = db
-        .insert("test-project", "original", &embedding_old, None)
+        .insert(
+            "test-project",
+            "original",
+            &embedding_old,
+            None,
+            "fact",
+            "active",
+        )
         .unwrap();
 
     db.update(&id, Some("updated"), Some(&embedding_new), None)
@@ -80,7 +94,14 @@ fn test_delete_memory() {
     let embedding = vec![0.5f32; 384];
 
     let id = db
-        .insert("test-project", "to delete", &embedding, None)
+        .insert(
+            "test-project",
+            "to delete",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
         .unwrap();
     assert!(db.delete(&id).unwrap());
 
@@ -122,16 +143,23 @@ fn test_list_by_project() {
     let db = Database::open(&path).unwrap();
     let embedding = vec![0.5f32; 384];
 
-    db.insert("project-a", "content a", &embedding, None)
+    db.insert("project-a", "content a", &embedding, None, "fact", "active")
         .unwrap();
-    db.insert("project-b", "content b", &embedding, None)
+    db.insert("project-b", "content b", &embedding, None, "fact", "active")
         .unwrap();
-    db.insert("project-a", "content a2", &embedding, None)
-        .unwrap();
+    db.insert(
+        "project-a",
+        "content a2",
+        &embedding,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
-    let memories_a = db.list("project-a", 10).unwrap();
+    let memories_a = db.list("project-a", 10, None, None).unwrap();
     assert_eq!(memories_a.len(), 2);
 
-    let memories_b = db.list("project-b", 10).unwrap();
+    let memories_b = db.list("project-b", 10, None, None).unwrap();
     assert_eq!(memories_b.len(), 1);
 }

--- a/src/memory/tests/ingest.rs
+++ b/src/memory/tests/ingest.rs
@@ -123,7 +123,7 @@ fn test_ingest_force_bypasses_conflicts() {
         AddResult::Added { id } => {
             assert!(!id.is_empty());
             // Verify both memories exist
-            let memories = store.list("test-project", 10).unwrap();
+            let memories = store.list("test-project", 10, None, None).unwrap();
             assert_eq!(memories.len(), 2);
         }
         AddResult::Conflicts { .. } => panic!("Expected AddResult::Added with Force policy"),

--- a/src/memory/tests/search.rs
+++ b/src/memory/tests/search.rs
@@ -15,12 +15,28 @@ fn test_search_basic() {
     let embedding_other = vec![0.0f32; 384];
 
     let id_match = db
-        .insert("test-project", "matching content", &embedding_match, None)
+        .insert(
+            "test-project",
+            "matching content",
+            &embedding_match,
+            None,
+            "fact",
+            "active",
+        )
         .unwrap();
-    db.insert("test-project", "other content", &embedding_other, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "other content",
+        &embedding_other,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
-    let results = db.search("test-project", &embedding_match, 5).unwrap();
+    let results = db
+        .search("test-project", &embedding_match, 5, None, None)
+        .unwrap();
     assert!(!results.is_empty());
     assert_eq!(results[0].id, id_match);
     assert!(results[0].similarity.unwrap() > 0.9);
@@ -38,14 +54,37 @@ fn test_search_sorting() {
     let embedding_medium = vec![0.5f32; 384];
     let embedding_low = vec![0.0f32; 384];
 
-    db.insert("test-project", "low", &embedding_low, None)
-        .unwrap();
-    db.insert("test-project", "high", &embedding_high, None)
-        .unwrap();
-    db.insert("test-project", "medium", &embedding_medium, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "low",
+        &embedding_low,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
+    db.insert(
+        "test-project",
+        "high",
+        &embedding_high,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
+    db.insert(
+        "test-project",
+        "medium",
+        &embedding_medium,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
-    let results = db.search("test-project", &embedding_high, 10).unwrap();
+    let results = db
+        .search("test-project", &embedding_high, 10, None, None)
+        .unwrap();
     assert!(results[0].similarity.unwrap() >= results[1].similarity.unwrap());
     assert!(results[1].similarity.unwrap() >= results[2].similarity.unwrap());
 }
@@ -61,10 +100,19 @@ fn test_negative_similarity() {
     let embedding_pos = vec![1.0f32; 384];
     let embedding_neg = vec![-1.0f32; 384];
 
-    db.insert("test-project", "positive", &embedding_pos, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "positive",
+        &embedding_pos,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
-    let results = db.search("test-project", &embedding_neg, 10).unwrap();
+    let results = db
+        .search("test-project", &embedding_neg, 10, None, None)
+        .unwrap();
     assert!(!results.is_empty());
     assert!(results[0].similarity.unwrap() < 0.0);
 }
@@ -102,6 +150,8 @@ fn test_hybrid_search_basic() {
             "rust programming language",
             &embedding_rust,
             None,
+            "fact",
+            "active",
         )
         .unwrap();
     let _id_python = db
@@ -110,6 +160,8 @@ fn test_hybrid_search_basic() {
             "python code examples",
             &embedding_python,
             None,
+            "fact",
+            "active",
         )
         .unwrap();
     let _id_general = db
@@ -118,11 +170,15 @@ fn test_hybrid_search_basic() {
             "general software development",
             &embedding_general,
             None,
+            "fact",
+            "active",
         )
         .unwrap();
 
     // Test hybrid search combines semantic and BM25
-    let semantic_results = db.search("test-project", &embedding_rust, 50).unwrap();
+    let semantic_results = db
+        .search("test-project", &embedding_rust, 50, None, None)
+        .unwrap();
     let bm25_results = db.search_bm25("rust", "test-project", 50).unwrap();
 
     // Verify semantic search finds rust-related content
@@ -154,11 +210,20 @@ fn test_hybrid_search_empty_results() {
 
     // Add one memory
     let embedding = vec![0.5f32; 384];
-    db.insert("test-project", "some content", &embedding, None)
-        .unwrap();
+    db.insert(
+        "test-project",
+        "some content",
+        &embedding,
+        None,
+        "fact",
+        "active",
+    )
+    .unwrap();
 
     // Query with non-matching text
-    let semantic_results = db.search("test-project", &vec![0.1f32; 384], 50).unwrap();
+    let semantic_results = db
+        .search("test-project", &vec![0.1f32; 384], 50, None, None)
+        .unwrap();
     let bm25_results = db
         .search_bm25("nonexistent term xyz", "test-project", 50)
         .unwrap();
@@ -195,6 +260,8 @@ fn test_hybrid_search_with_recency() {
             None,
             &old_time,
             &old_time,
+            "fact",
+            "active",
         )
         .unwrap();
 
@@ -207,11 +274,15 @@ fn test_hybrid_search_with_recency() {
             None,
             &new_time,
             &new_time,
+            "fact",
+            "active",
         )
         .unwrap();
 
     // Search without recency weighting - should find high-similarity first
-    let semantic_results = db.search("test-project", &embedding_good, 10).unwrap();
+    let semantic_results = db
+        .search("test-project", &embedding_good, 10, None, None)
+        .unwrap();
     if !semantic_results.is_empty() {
         let top_id = &semantic_results[0].id;
         // With zero recency weight, similarity dominates
@@ -234,7 +305,14 @@ fn test_integration_add_search_roundtrip() {
     let mut store = MemoryStore::new(&path, "BAAI/bge-small-en-v1.5", config).unwrap();
 
     let id = match store
-        .add_with_conflict("test-project", "semantic search is useful", None, false)
+        .add_with_conflict(
+            "test-project",
+            "semantic search is useful",
+            None,
+            false,
+            "fact",
+            "active",
+        )
         .unwrap()
     {
         crate::memory_types::AddResult::Added { id } => id,
@@ -242,7 +320,7 @@ fn test_integration_add_search_roundtrip() {
     };
 
     let results = store
-        .search("test-project", "finding information", 5, 0.0)
+        .search("test-project", "finding information", 5, 0.0, None, None)
         .unwrap();
     assert!(!results.is_empty());
 
@@ -264,7 +342,14 @@ fn test_integration_update_changes_embedding() {
     let mut store = MemoryStore::new(&path, "BAAI/bge-small-en-v1.5", config).unwrap();
 
     let id = match store
-        .add_with_conflict("test-project", "original content", None, false)
+        .add_with_conflict(
+            "test-project",
+            "original content",
+            None,
+            false,
+            "fact",
+            "active",
+        )
         .unwrap()
     {
         crate::memory_types::AddResult::Added { id } => id,

--- a/src/rrf.rs
+++ b/src/rrf.rs
@@ -128,6 +128,9 @@ mod tests {
             similarity,
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
+            memory_type: "fact".to_string(),
+            status: "active".to_string(),
+            superseded_by: None,
         }
     }
 
@@ -256,6 +259,9 @@ mod tests {
             similarity: Some(0.9),
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
+            memory_type: "fact".to_string(),
+            status: "active".to_string(),
+            superseded_by: None,
         };
 
         let fused = rrf_fusion(vec![vec![memory]], None).unwrap();

--- a/src/sqlite/fts.rs
+++ b/src/sqlite/fts.rs
@@ -137,7 +137,7 @@ impl Database {
         }
 
         let sql = r#"
-            SELECT m.id, m.project_id, m.content, m.metadata, m.embedding, m.created_at, m.updated_at,
+            SELECT m.id, m.project_id, m.content, m.metadata, m.embedding, m.created_at, m.updated_at, m.type, m.status, m.superseded_by,
                    bm25(memories_fts) as bm25_score
             FROM memories_fts
             JOIN memories m ON m.rowid = memories_fts.rowid
@@ -166,7 +166,10 @@ impl Database {
                     embedding,
                     created_at: row.get(5)?,
                     updated_at: row.get(6)?,
-                    similarity: Some(row.get::<_, f64>(7)?),
+                    memory_type: row.get(7)?,
+                    status: row.get(8)?,
+                    superseded_by: row.get(9)?,
+                    similarity: Some(row.get::<_, f64>(10)?),
                 })
             })?
             .collect();
@@ -225,9 +228,17 @@ mod tests {
     fn test_fts5_search() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "rust programming", &embedding, None)
+        db.insert(
+            "proj1",
+            "rust programming",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert("proj1", "python data", &embedding, None, "fact", "active")
             .unwrap();
-        db.insert("proj1", "python data", &embedding, None).unwrap();
 
         let results = db.search_bm25("rust", "proj1", 10).unwrap();
         assert_eq!(results.len(), 1);
@@ -239,7 +250,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         let id = db
-            .insert("proj1", "original text", &embedding, None)
+            .insert("proj1", "original text", &embedding, None, "fact", "active")
             .unwrap();
 
         assert_eq!(db.search_bm25("original", "proj1", 10).unwrap().len(), 1);
@@ -263,12 +274,33 @@ mod tests {
     fn test_fts5_special_characters() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "test with \"quotes\"", &embedding, None)
-            .unwrap();
-        db.insert("proj1", "test with 'apos'", &embedding, None)
-            .unwrap();
-        db.insert("proj1", "test with\\slash", &embedding, None)
-            .unwrap();
+        db.insert(
+            "proj1",
+            "test with \"quotes\"",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert(
+            "proj1",
+            "test with 'apos'",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert(
+            "proj1",
+            "test with\\slash",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
 
         assert_eq!(
             db.search_bm25("test with \"quotes\"", "proj1", 10)
@@ -290,7 +322,7 @@ mod tests {
     fn test_fts5_empty_query() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "test content", &embedding, None)
+        db.insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         // Empty query returns no results
@@ -302,10 +334,24 @@ mod tests {
     fn test_fts5_phrase_search() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "rust programming", &embedding, None)
-            .unwrap();
-        db.insert("proj1", "rust error handling", &embedding, None)
-            .unwrap();
+        db.insert(
+            "proj1",
+            "rust programming",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert(
+            "proj1",
+            "rust error handling",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
 
         // Multi-word phrase should find matching content
         let results = db.search_bm25("rust programming", "proj1", 10).unwrap();
@@ -317,8 +363,15 @@ mod tests {
     fn test_fts5_unicode_text() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "café résumé 日本語", &embedding, None)
-            .unwrap();
+        db.insert(
+            "proj1",
+            "café résumé 日本語",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
 
         // Test basic Unicode matching
         let results = db.search_bm25("café", "proj1", 10).unwrap();
@@ -334,8 +387,15 @@ mod tests {
 
         {
             let db = Database::open(&path).unwrap();
-            db.insert("proj1", "before migration", &vec![0.1f32; 384], None)
-                .unwrap();
+            db.insert(
+                "proj1",
+                "before migration",
+                &vec![0.1f32; 384],
+                None,
+                "fact",
+                "active",
+            )
+            .unwrap();
         }
 
         {
@@ -354,11 +414,18 @@ mod tests {
         // Initial data with 3 rows
         {
             let db = Database::open(&path).unwrap();
-            db.insert("proj1", "first", &vec![0.1f32; 384], None)
+            db.insert("proj1", "first", &vec![0.1f32; 384], None, "fact", "active")
                 .unwrap();
-            db.insert("proj1", "second", &vec![0.1f32; 384], None)
-                .unwrap();
-            db.insert("proj1", "third", &vec![0.1f32; 384], None)
+            db.insert(
+                "proj1",
+                "second",
+                &vec![0.1f32; 384],
+                None,
+                "fact",
+                "active",
+            )
+            .unwrap();
+            db.insert("proj1", "third", &vec![0.1f32; 384], None, "fact", "active")
                 .unwrap();
         }
 

--- a/src/sqlite/migrations.rs
+++ b/src/sqlite/migrations.rs
@@ -79,9 +79,29 @@ fn migrate_v1(_conn: &Connection) -> SqliteResult<()> {
     Ok(())
 }
 
+/// Migration 2: Add memory type, lifecycle status, and supersession tracking.
+///
+/// Adds three columns to the memories table:
+/// - `type`: Memory type (fact/preference/procedure/guard/observation), defaults to 'fact'
+/// - `status`: Lifecycle status (active/candidate/superseded/deprecated), defaults to 'active'
+/// - `superseded_by`: ID of the memory that superseded this one (nullable)
+///
+/// Also creates indexes for efficient filtering by type and status.
+fn migrate_v2(conn: &Connection) -> SqliteResult<()> {
+    conn.execute_batch(
+        "ALTER TABLE memories ADD COLUMN type TEXT NOT NULL DEFAULT 'fact';
+         ALTER TABLE memories ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+         ALTER TABLE memories ADD COLUMN superseded_by TEXT;
+         CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
+         CREATE INDEX IF NOT EXISTS idx_memories_status ON memories(status);
+         CREATE INDEX IF NOT EXISTS idx_memories_project_status ON memories(project_id, status);",
+    )?;
+    Ok(())
+}
+
 /// Returns all migrations in order. Index 0 = migration 1, etc.
 fn migrations() -> Vec<MigrationFn> {
-    vec![migrate_v1]
+    vec![migrate_v1, migrate_v2]
 }
 
 /// Returns the total number of migrations available (i.e., the max supported schema version).
@@ -180,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fresh_db_version_becomes_1() {
+    fn test_fresh_db_version_becomes_2() {
         let conn = create_test_db();
         init_schema(&conn).unwrap();
 
@@ -193,37 +213,37 @@ mod tests {
         // Run migrations
         run_migrations(&conn).unwrap();
 
-        // Version should now be 1
+        // Version should now be 2
         let final_version: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(final_version, 1);
+        assert_eq!(final_version, 2);
     }
 
     #[test]
-    fn test_already_at_version_1_is_noop() {
+    fn test_already_at_version_2_is_noop() {
         let conn = create_test_db();
         init_schema(&conn).unwrap();
 
-        // Run migrations first time: 0 → 1
+        // Run migrations first time: 0 → 2
         run_migrations(&conn).unwrap();
 
         let version: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 1);
+        assert_eq!(version, 2);
 
-        // Run again: should be no-op (already at version 1)
+        // Run again: should be no-op (already at version 2)
         run_migrations(&conn).unwrap();
 
         let version_after: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(version_after, 1);
+        assert_eq!(version_after, 2);
     }
 
     #[test]
-    fn test_upgrade_from_v0_to_v1() {
+    fn test_upgrade_from_v0_to_v2() {
         let conn = create_test_db();
         init_schema(&conn).unwrap();
 
@@ -237,11 +257,11 @@ mod tests {
         // Run migrations
         run_migrations(&conn).unwrap();
 
-        // Should upgrade from 0 to 1
+        // Should upgrade from 0 to 2
         let final_version: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(final_version, 1);
+        assert_eq!(final_version, 2);
     }
 
     #[test]
@@ -254,11 +274,11 @@ mod tests {
             run_migrations(&conn).unwrap();
         }
 
-        // Version should be 1 (not incrementing on re-run)
+        // Version should be 2 (not incrementing on re-run)
         let version: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(version, 1);
+        assert_eq!(version, 2);
     }
 
     #[test]
@@ -297,7 +317,7 @@ mod tests {
         let final_version: i32 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .unwrap();
-        assert_eq!(final_version, 1);
+        assert_eq!(final_version, 2);
     }
 
     #[test]

--- a/src/sqlite/mod.rs
+++ b/src/sqlite/mod.rs
@@ -47,6 +47,15 @@ pub struct Memory {
     pub created_at: String,
     /// Last update timestamp in RFC3339 format.
     pub updated_at: String,
+    /// Memory type (fact, preference, procedure, guard, observation).
+    #[allow(dead_code)] // Library API: exposed for consumers
+    pub memory_type: String,
+    /// Lifecycle status (active, candidate, superseded, deprecated).
+    #[allow(dead_code)] // Library API: exposed for consumers
+    pub status: String,
+    /// ID of the memory that superseded this one (if any).
+    #[allow(dead_code)] // Library API: exposed for consumers
+    pub superseded_by: Option<String>,
 }
 
 /// Error types for SQLite operations.
@@ -64,6 +73,10 @@ pub enum Error {
     InvalidEmbedding(String),
     /// Invalid search limit value.
     InvalidLimit(String),
+    /// Entity not found.
+    NotFound(String),
+    /// Invalid input provided.
+    InvalidInput(String),
 }
 
 impl std::fmt::Display for Error {
@@ -87,6 +100,8 @@ impl std::fmt::Display for Error {
             Error::EmptyVector => write!(f, "Cannot compute similarity with empty vector"),
             Error::InvalidEmbedding(msg) => write!(f, "Invalid embedding: {}", msg),
             Error::InvalidLimit(msg) => write!(f, "Invalid limit: {}", msg),
+            Error::NotFound(msg) => write!(f, "Not found: {}", msg),
+            Error::InvalidInput(msg) => write!(f, "Invalid input: {}", msg),
         }
     }
 }
@@ -185,6 +200,8 @@ impl Database {
         content: &str,
         embedding: &[f32],
         metadata: Option<&str>,
+        memory_type: &str,
+        status: &str,
     ) -> Result<String> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
@@ -192,10 +209,10 @@ impl Database {
 
         self.conn.execute(
             r#"
-            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at, type, status)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             "#,
-            params![&id, project_id, content, &blob, metadata, &now, &now],
+            params![&id, project_id, content, &blob, metadata, &now, &now, memory_type, status],
         )?;
 
         Ok(id)
@@ -213,16 +230,18 @@ impl Database {
         metadata: Option<&str>,
         created_at: &str,
         updated_at: &str,
+        memory_type: &str,
+        status: &str,
     ) -> Result<String> {
         let id = Uuid::new_v4().to_string();
         let blob = vec_to_blob(embedding)?;
 
         self.conn.execute(
             r#"
-            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at, type, status)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             "#,
-            params![&id, project_id, content, &blob, metadata, created_at, updated_at],
+            params![&id, project_id, content, &blob, metadata, created_at, updated_at, memory_type, status],
         )?;
 
         Ok(id)
@@ -238,7 +257,7 @@ impl Database {
     pub fn get(&self, id: &str) -> Result<Option<Memory>> {
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT id, project_id, content, metadata, embedding, created_at, updated_at
+            SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
             FROM memories
             WHERE id = ?1
             "#,
@@ -250,22 +269,82 @@ impl Database {
 
     /// List memories for a project, ordered by creation time (newest first).
     ///
+    /// # Arguments
+    ///
+    /// * `project_id` - Project identifier
+    /// * `limit` - Maximum number of results to return
+    /// * `memory_types` - Optional filter for memory types (None = no filter by type)
+    /// * `statuses` - Optional filter for lifecycle statuses (None = default to 'active')
+    ///
     /// # Errors
     ///
     /// Returns error if the limit is invalid or the query fails.
-    pub fn list(&self, project_id: &str, limit: usize) -> Result<Vec<Memory>> {
-        let mut stmt = self.conn.prepare(
-            r#"
-            SELECT id, project_id, content, metadata, embedding, created_at, updated_at
-            FROM memories
-            WHERE project_id = ?1
-            ORDER BY created_at DESC
-            LIMIT ?2
-            "#,
-        )?;
+    pub fn list(
+        &self,
+        project_id: &str,
+        limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
+    ) -> Result<Vec<Memory>> {
+        let mut where_clauses = vec!["project_id = ?1".to_string()];
+        let mut param_index = 2usize;
+
+        // Status filter (default to active if None)
+        if let Some(statuses) = statuses {
+            if !statuses.is_empty() {
+                let placeholders: Vec<String> = (0..statuses.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("status IN ({})", placeholders.join(", ")));
+                param_index += statuses.len();
+            }
+        } else {
+            where_clauses.push(format!("status = ?{}", param_index));
+            param_index += 1;
+        }
+
+        // Type filter (only if explicitly provided)
+        if let Some(types) = memory_types {
+            if !types.is_empty() {
+                let placeholders: Vec<String> = (0..types.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("type IN ({})", placeholders.join(", ")));
+                param_index += types.len();
+            }
+        }
+
+        let where_clause = where_clauses.join(" AND ");
+        let query = format!(
+            "SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
+             FROM memories WHERE {} ORDER BY created_at DESC LIMIT ?{}",
+            where_clause, param_index
+        );
+
+        let mut stmt = self.conn.prepare(&query)?;
+
+        let mut params: Vec<&dyn rusqlite::ToSql> = vec![&project_id];
+        if let Some(statuses) = statuses {
+            if statuses.is_empty() {
+                // explicit empty = no status filter, but we didn't add a clause
+            } else {
+                for s in statuses {
+                    params.push(s);
+                }
+            }
+        } else {
+            params.push(&"active");
+        }
+        if let Some(types) = memory_types {
+            for t in types {
+                params.push(t);
+            }
+        }
+        let limit_param = limit as i64;
+        params.push(&limit_param);
 
         let memories: SqliteResult<Vec<Memory>> = stmt
-            .query_map(params![project_id, limit as i64], map_row_to_memory)?
+            .query_map(params.as_slice(), map_row_to_memory)?
             .collect();
 
         Ok(memories?)
@@ -370,6 +449,60 @@ impl Database {
         Ok(rows > 0)
     }
 
+    /// Atomically supersede an old memory with a new one.
+    ///
+    /// In a single transaction:
+    /// 1. Inserts the new memory
+    /// 2. Sets old memory's status to 'superseded' and superseded_by to new ID
+    #[allow(dead_code)] // Public API: used by CLI --supersedes flag and library consumers
+    pub fn supersede(
+        &self,
+        project_id: &str,
+        content: &str,
+        embedding: &[f32],
+        metadata: Option<&str>,
+        memory_type: &str,
+        old_id: &str,
+    ) -> Result<String> {
+        // Verify old memory exists
+        let old = self
+            .get(old_id)?
+            .ok_or_else(|| Error::NotFound(format!("memory to supersede not found: {}", old_id)))?;
+        if old.project_id != project_id {
+            return Err(Error::InvalidInput(
+                "cannot supersede memory from different project".to_string(),
+            ));
+        }
+
+        let new_id = Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let blob = vec_to_blob(embedding)?;
+
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at, type, status)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                &new_id,
+                project_id,
+                content,
+                &blob,
+                metadata,
+                &now,
+                &now,
+                memory_type,
+                "active"
+            ],
+        )?;
+        tx.execute(
+            "UPDATE memories SET status = 'superseded', superseded_by = ?1, updated_at = ?2 WHERE id = ?3",
+            params![&new_id, &now, old_id],
+        )?;
+        tx.commit()?;
+
+        Ok(new_id)
+    }
+
     /// List memories for a project created since a given timestamp.
     ///
     /// Returns memories with `created_at > since_timestamp`, ordered by creation time (newest first).
@@ -380,6 +513,8 @@ impl Database {
     /// * `project_id` - Project identifier
     /// * `since_timestamp` - RFC3339-formatted timestamp (exclusive lower bound)
     /// * `limit` - Maximum number of results to return
+    /// * `memory_types` - Optional filter for memory types (None = no filter by type)
+    /// * `statuses` - Optional filter for lifecycle statuses (None = default to 'active')
     ///
     /// # Errors
     ///
@@ -393,7 +528,7 @@ impl Database {
     /// ```ignore
     /// use chrono::Utc;
     /// let one_hour_ago = (Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
-    /// let recent = db.list_since("project", &one_hour_ago, 10)?;
+    /// let recent = db.list_since("project", &one_hour_ago, 10, None, None)?;
     /// ```
     #[allow(dead_code)] // Public API for library consumers (e.g., kide)
     pub fn list_since(
@@ -401,26 +536,72 @@ impl Database {
         project_id: &str,
         since_timestamp: &str,
         limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<Vec<Memory>> {
         // Validate timestamp format by parsing it
         let _parsed = chrono::DateTime::parse_from_rfc3339(since_timestamp)
             .map_err(|e| Error::Sqlite(format!("Invalid RFC3339 timestamp: {}", e)))?;
 
-        let mut stmt = self.conn.prepare(
-            r#"
-            SELECT id, project_id, content, metadata, embedding, created_at, updated_at
-            FROM memories
-            WHERE project_id = ?1 AND created_at > ?2
-            ORDER BY created_at DESC
-            LIMIT ?3
-            "#,
-        )?;
+        let mut where_clauses = vec!["project_id = ?1".to_string(), "created_at > ?2".to_string()];
+        let mut param_index = 3usize;
+
+        // Status filter (default to active if None)
+        if let Some(statuses) = statuses {
+            if !statuses.is_empty() {
+                let placeholders: Vec<String> = (0..statuses.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("status IN ({})", placeholders.join(", ")));
+                param_index += statuses.len();
+            }
+        } else {
+            where_clauses.push(format!("status = ?{}", param_index));
+            param_index += 1;
+        }
+
+        // Type filter (only if explicitly provided)
+        if let Some(types) = memory_types {
+            if !types.is_empty() {
+                let placeholders: Vec<String> = (0..types.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("type IN ({})", placeholders.join(", ")));
+                param_index += types.len();
+            }
+        }
+
+        let where_clause = where_clauses.join(" AND ");
+        let query = format!(
+            "SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
+             FROM memories WHERE {} ORDER BY created_at DESC LIMIT ?{}",
+            where_clause, param_index
+        );
+
+        let mut stmt = self.conn.prepare(&query)?;
+
+        let mut params: Vec<&dyn rusqlite::ToSql> = vec![&project_id, &since_timestamp];
+        if let Some(statuses) = statuses {
+            if statuses.is_empty() {
+                // explicit empty = no status filter, but we didn't add a clause
+            } else {
+                for s in statuses {
+                    params.push(s);
+                }
+            }
+        } else {
+            params.push(&"active");
+        }
+        if let Some(types) = memory_types {
+            for t in types {
+                params.push(t);
+            }
+        }
+        let limit_param = limit as i64;
+        params.push(&limit_param);
 
         let memories: SqliteResult<Vec<Memory>> = stmt
-            .query_map(
-                params![project_id, since_timestamp, limit as i64],
-                map_row_to_memory,
-            )?
+            .query_map(params.as_slice(), map_row_to_memory)?
             .collect();
 
         Ok(memories?)
@@ -466,7 +647,7 @@ impl Database {
             .join(", ");
         let query = format!(
             r#"
-            SELECT id, project_id, content, metadata, embedding, created_at, updated_at
+            SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
             FROM memories
             WHERE id IN ({})
             "#,
@@ -499,6 +680,9 @@ impl Database {
                         similarity: None,
                         created_at: row.get(5)?,
                         updated_at: row.get(6)?,
+                        memory_type: row.get(7)?,
+                        status: row.get(8)?,
+                        superseded_by: row.get(9)?,
                     },
                 ))
             })?
@@ -541,7 +725,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         let id = db
-            .insert("proj1", "test content", &embedding, None)
+            .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         let memory = db.get(&id).unwrap();
@@ -561,6 +745,8 @@ mod tests {
                 "test content",
                 &embedding,
                 Some(r#"{"key": "value"}"#),
+                "fact",
+                "active",
             )
             .unwrap();
 
@@ -572,7 +758,7 @@ mod tests {
     fn test_insert_invalid_embedding() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 256];
-        let result = db.insert("proj1", "test", &embedding, None);
+        let result = db.insert("proj1", "test", &embedding, None, "fact", "active");
         assert!(result.is_err());
     }
 
@@ -595,6 +781,8 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let id2 = db
@@ -605,10 +793,12 @@ mod tests {
                 None,
                 "2024-01-02T00:00:00Z",
                 "2024-01-02T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
-        let memories = db.list("proj1", 10).unwrap();
+        let memories = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(memories.len(), 2);
         assert_eq!(memories[0].id, id2); // Newest first
         assert_eq!(memories[1].id, id1);
@@ -619,11 +809,18 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         for i in 0..5 {
-            db.insert("proj1", &format!("content {}", i), &embedding, None)
-                .unwrap();
+            db.insert(
+                "proj1",
+                &format!("content {}", i),
+                &embedding,
+                None,
+                "fact",
+                "active",
+            )
+            .unwrap();
         }
 
-        let memories = db.list("proj1", 2).unwrap();
+        let memories = db.list("proj1", 2, None, None).unwrap();
         assert_eq!(memories.len(), 2);
     }
 
@@ -631,7 +828,9 @@ mod tests {
     fn test_update() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "original", &embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "original", &embedding, None, "fact", "active")
+            .unwrap();
 
         db.update(&id, Some("updated"), Some(&embedding), None)
             .unwrap();
@@ -645,7 +844,14 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         let id = db
-            .insert("proj1", "original", &embedding, Some(r#"{"tag": "old"}"#))
+            .insert(
+                "proj1",
+                "original",
+                &embedding,
+                Some(r#"{"tag": "old"}"#),
+                "fact",
+                "active",
+            )
             .unwrap();
 
         let new_embedding = vec![0.2f32; 384];
@@ -661,7 +867,9 @@ mod tests {
     fn test_update_metadata_only() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "original", &embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "original", &embedding, None, "fact", "active")
+            .unwrap();
 
         db.update(&id, None, None, Some(r#"{"tag": "new"}"#))
             .unwrap();
@@ -676,7 +884,14 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         let id = db
-            .insert("proj1", "original", &embedding, Some(r#"{"tag": "old"}"#))
+            .insert(
+                "proj1",
+                "original",
+                &embedding,
+                Some(r#"{"tag": "old"}"#),
+                "fact",
+                "active",
+            )
             .unwrap();
 
         let new_embedding = vec![0.2f32; 384];
@@ -697,7 +912,9 @@ mod tests {
     fn test_update_with_none_both() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "original", &embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "original", &embedding, None, "fact", "active")
+            .unwrap();
 
         let result = db.update(&id, None, None, None);
         assert!(result.is_err());
@@ -715,7 +932,9 @@ mod tests {
     fn test_delete() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "content", &embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "content", &embedding, None, "fact", "active")
+            .unwrap();
 
         let deleted = db.delete(&id).unwrap();
         assert!(deleted);
@@ -735,13 +954,13 @@ mod tests {
     fn test_project_isolation() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "proj1 content", &embedding, None)
+        db.insert("proj1", "proj1 content", &embedding, None, "fact", "active")
             .unwrap();
-        db.insert("proj2", "proj2 content", &embedding, None)
+        db.insert("proj2", "proj2 content", &embedding, None, "fact", "active")
             .unwrap();
 
-        let list1 = db.list("proj1", 10).unwrap();
-        let list2 = db.list("proj2", 10).unwrap();
+        let list1 = db.list("proj1", 10, None, None).unwrap();
+        let list2 = db.list("proj2", 10, None, None).unwrap();
 
         assert_eq!(list1.len(), 1);
         assert_eq!(list2.len(), 1);
@@ -754,7 +973,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; EMBEDDING_DIMS];
         let id = db
-            .insert("proj1", "test content", &embedding, None)
+            .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         let memory = db.get(&id).unwrap().unwrap();
@@ -770,10 +989,12 @@ mod tests {
         let embedding1 = vec![0.1f32; EMBEDDING_DIMS];
         let embedding2 = vec![0.2f32; EMBEDDING_DIMS];
 
-        db.insert("proj1", "first", &embedding1, None).unwrap();
-        db.insert("proj1", "second", &embedding2, None).unwrap();
+        db.insert("proj1", "first", &embedding1, None, "fact", "active")
+            .unwrap();
+        db.insert("proj1", "second", &embedding2, None, "fact", "active")
+            .unwrap();
 
-        let memories = db.list("proj1", 10).unwrap();
+        let memories = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(memories.len(), 2);
 
         for memory in &memories {
@@ -790,7 +1011,9 @@ mod tests {
         full_embedding[1] = original[1];
         full_embedding[EMBEDDING_DIMS - 1] = original[2];
 
-        let id = db.insert("proj1", "test", &full_embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "test", &full_embedding, None, "fact", "active")
+            .unwrap();
 
         let memory = db.get(&id).unwrap().unwrap();
         assert_eq!(memory.embedding.len(), EMBEDDING_DIMS);

--- a/src/sqlite/query_mod.rs
+++ b/src/sqlite/query_mod.rs
@@ -43,6 +43,9 @@ pub fn map_row_to_memory(row: &Row) -> SqliteResult<Memory> {
         similarity: None,
         created_at: row.get(5)?,
         updated_at: row.get(6)?,
+        memory_type: row.get(7)?,
+        status: row.get(8)?,
+        superseded_by: row.get(9)?,
     })
 }
 
@@ -71,6 +74,8 @@ mod tests {
                 "test content",
                 &embedding,
                 Some(r#"{"key":"value"}"#),
+                "fact",
+                "active",
             )
             .unwrap();
 
@@ -78,7 +83,7 @@ mod tests {
         let mut stmt = conn
             .prepare(
                 r#"
-                SELECT id, project_id, content, metadata, embedding, created_at, updated_at
+                SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
                 FROM memories
                 WHERE id = ?1
                 "#,
@@ -99,14 +104,14 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; EMBEDDING_DIMS];
         let id = db
-            .insert("proj1", "test content", &embedding, None)
+            .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         let conn = db.conn();
         let mut stmt = conn
             .prepare(
                 r#"
-                SELECT id, project_id, content, metadata, embedding, created_at, updated_at
+                SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
                 FROM memories
                 WHERE id = ?1
                 "#,
@@ -126,8 +131,8 @@ mod tests {
         let blob = super::super::embedding::vec_to_blob(&vec![0.1f32; EMBEDDING_DIMS]).unwrap();
         conn.execute(
             r#"
-            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at)
-            VALUES ('test-id', 'proj1', 'test', ?1, NULL, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')
+            INSERT INTO memories (id, project_id, content, embedding, metadata, created_at, updated_at, type, status)
+            VALUES ('test-id', 'proj1', 'test', ?1, NULL, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', 'fact', 'active')
             "#,
             params![blob],
         )
@@ -136,7 +141,7 @@ mod tests {
         let mut stmt = conn
             .prepare(
                 r#"
-                SELECT id, project_id, content, metadata, embedding, created_at, updated_at
+                SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
                 FROM memories
                 WHERE id = ?1
                 "#,

--- a/src/sqlite/search.rs
+++ b/src/sqlite/search.rs
@@ -27,6 +27,14 @@ impl Database {
     /// Retrieves all memories for a project, computes cosine similarity with the query
     /// embedding, sorts by similarity (highest first), and returns the top `limit` results.
     ///
+    /// # Arguments
+    ///
+    /// * `project_id` - Project identifier
+    /// * `query_embedding` - The embedding vector to compare against
+    /// * `limit` - Maximum number of results to return
+    /// * `memory_types` - Optional filter for memory types (None = no filter by type)
+    /// * `statuses` - Optional filter for lifecycle statuses (None = default to 'active')
+    ///
     /// # Errors
     ///
     /// Returns error if the query embedding has invalid dimensions or if the database
@@ -36,33 +44,95 @@ impl Database {
         project_id: &str,
         query_embedding: &[f32],
         limit: usize,
+        memory_types: Option<&[&str]>,
+        statuses: Option<&[&str]>,
     ) -> Result<Vec<Memory>> {
         validate_limit(limit)?;
 
-        let mut stmt = self.conn.prepare(
-            r#"
-            SELECT id, project_id, content, metadata, created_at, updated_at, embedding
-            FROM memories
-            WHERE project_id = ?1
-            "#,
-        )?;
+        let mut where_clauses = vec!["project_id = ?1".to_string()];
+        let mut param_index = 2usize;
+
+        // Status filter (default to active if None)
+        if let Some(statuses) = statuses {
+            if !statuses.is_empty() {
+                let placeholders: Vec<String> = (0..statuses.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("status IN ({})", placeholders.join(", ")));
+                param_index += statuses.len();
+            }
+        } else {
+            where_clauses.push(format!("status = ?{}", param_index));
+            param_index += 1;
+        }
+
+        // Type filter (only if explicitly provided)
+        if let Some(types) = memory_types {
+            if !types.is_empty() {
+                let placeholders: Vec<String> = (0..types.len())
+                    .map(|i| format!("?{}", param_index + i))
+                    .collect();
+                where_clauses.push(format!("type IN ({})", placeholders.join(", ")));
+            }
+        }
+
+        let where_clause = where_clauses.join(" AND ");
+        let query = format!(
+            "SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by
+             FROM memories WHERE {} ORDER BY created_at DESC",
+            where_clause
+        );
+
+        let mut stmt = self.conn.prepare(&query)?;
+
+        let mut params: Vec<&dyn rusqlite::ToSql> = vec![&project_id];
+        if let Some(statuses) = statuses {
+            if statuses.is_empty() {
+                // explicit empty = no status filter, but we didn't add a clause
+            } else {
+                for s in statuses {
+                    params.push(s);
+                }
+            }
+        } else {
+            params.push(&"active");
+        }
+        if let Some(types) = memory_types {
+            for t in types {
+                params.push(t);
+            }
+        }
 
         let mut memories: Vec<Memory> = Vec::new();
 
-        let rows = stmt.query_map([project_id], |row| {
+        let rows = stmt.query_map(params.as_slice(), |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
                 row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
+                row.get::<_, Vec<u8>>(4)?,
                 row.get::<_, String>(5)?,
-                row.get::<_, Vec<u8>>(6)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, Option<String>>(9)?,
             ))
         })?;
 
         for row_result in rows {
-            let (id, pid, content, metadata, created_at, updated_at, blob) = row_result?;
+            let (
+                id,
+                pid,
+                content,
+                metadata,
+                blob,
+                created_at,
+                updated_at,
+                type_val,
+                status_val,
+                superseded_by,
+            ) = row_result?;
             let stored_embedding = embedding::blob_to_vec(&blob).map_err(|e| {
                 rusqlite::Error::FromSqlConversionFailure(
                     6,
@@ -84,6 +154,9 @@ impl Database {
                 similarity,
                 created_at,
                 updated_at,
+                memory_type: type_val,
+                status: status_val,
+                superseded_by,
             });
         }
 
@@ -111,7 +184,7 @@ impl Database {
         embedding: &[f32],
         threshold: f64,
     ) -> Result<Vec<Memory>> {
-        let all_results = self.search(project_id, embedding, MAX_SEARCH_LIMIT)?;
+        let all_results = self.search(project_id, embedding, MAX_SEARCH_LIMIT, None, None)?;
         Ok(all_results
             .into_iter()
             .filter(|m| m.similarity.unwrap_or(0.0) >= threshold)
@@ -152,12 +225,26 @@ mod tests {
     fn test_search_basic() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "rust programming", &embedding, None)
-            .unwrap();
-        db.insert("proj1", "python data science", &embedding, None)
-            .unwrap();
+        db.insert(
+            "proj1",
+            "rust programming",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert(
+            "proj1",
+            "python data science",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
 
-        let results = db.search("proj1", &embedding, 10).unwrap();
+        let results = db.search("proj1", &embedding, 10, None, None).unwrap();
         assert_eq!(results.len(), 2);
         assert!(results[0].similarity.unwrap() >= 0.9);
     }
@@ -167,11 +254,18 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         for i in 0..5 {
-            db.insert("proj1", &format!("content {}", i), &embedding, None)
-                .unwrap();
+            db.insert(
+                "proj1",
+                &format!("content {}", i),
+                &embedding,
+                None,
+                "fact",
+                "active",
+            )
+            .unwrap();
         }
 
-        let results = db.search("proj1", &embedding, 2).unwrap();
+        let results = db.search("proj1", &embedding, 2, None, None).unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -179,12 +273,26 @@ mod tests {
     fn test_search_project_isolation() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "project 1 memory", &embedding, None)
-            .unwrap();
-        db.insert("proj2", "project 2 memory", &embedding, None)
-            .unwrap();
+        db.insert(
+            "proj1",
+            "project 1 memory",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
+        db.insert(
+            "proj2",
+            "project 2 memory",
+            &embedding,
+            None,
+            "fact",
+            "active",
+        )
+        .unwrap();
 
-        let results = db.search("proj1", &embedding, 10).unwrap();
+        let results = db.search("proj1", &embedding, 10, None, None).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].project_id, "proj1");
     }
@@ -196,8 +304,10 @@ mod tests {
         let mut embedding2 = vec![1.0f32; 384];
         embedding2[0] = 0.0; // Slightly different
 
-        db.insert("proj1", "memory 1", &embedding1, None).unwrap();
-        db.insert("proj1", "memory 2", &embedding2, None).unwrap();
+        db.insert("proj1", "memory 1", &embedding1, None, "fact", "active")
+            .unwrap();
+        db.insert("proj1", "memory 2", &embedding2, None, "fact", "active")
+            .unwrap();
 
         let results = db.find_similar("proj1", &embedding1, 0.99).unwrap();
         assert!(!results.is_empty());

--- a/src/sqlite/tests.rs
+++ b/src/sqlite/tests.rs
@@ -25,6 +25,8 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let _id2 = db
@@ -35,11 +37,13 @@ mod tests {
                 None,
                 "2024-01-02T00:00:00Z",
                 "2024-01-02T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
         // List since 2024-01-01T12:00:00Z should only return "new"
-        let results = db.list_since("proj1", "2024-01-01T12:00:00Z", 10).unwrap();
+        let results = db.list_since("proj1", "2024-01-01T12:00:00Z", 10, None, None).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].content, "new");
     }
@@ -57,15 +61,17 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
         // List since exact timestamp should NOT return the memory (exclusive)
-        let results = db.list_since("proj1", "2024-01-01T00:00:00Z", 10).unwrap();
+        let results = db.list_since("proj1", "2024-01-01T00:00:00Z", 10, None, None).unwrap();
         assert_eq!(results.len(), 0);
 
         // But list since 1ms before SHOULD return it
-        let results = db.list_since("proj1", "2023-12-31T23:59:59Z", 10).unwrap();
+        let results = db.list_since("proj1", "2023-12-31T23:59:59Z", 10, None, None).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, id);
     }
@@ -73,7 +79,7 @@ mod tests {
     #[test]
     fn test_list_since_invalid_timestamp() {
         let db = create_test_db();
-        let result = db.list_since("proj1", "invalid-timestamp", 10);
+        let result = db.list_since("proj1", "invalid-timestamp", 10, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid RFC3339"));
     }
@@ -91,12 +97,14 @@ mod tests {
                 None,
                 &format!("2024-01-{:02}T00:00:00Z", i + 1),
                 &format!("2024-01-{:02}T00:00:00Z", i + 1),
+                "fact",
+                "active",
             )
             .unwrap();
         }
 
         // Should only return 2 most recent
-        let results = db.list_since("proj1", "2024-01-01T00:00:00Z", 2).unwrap();
+        let results = db.list_since("proj1", "2024-01-01T00:00:00Z", 2, None, None).unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -113,6 +121,8 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let id2 = db
@@ -123,6 +133,8 @@ mod tests {
                 None,
                 "2024-01-02T00:00:00Z",
                 "2024-01-02T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let id3 = db
@@ -133,11 +145,13 @@ mod tests {
                 None,
                 "2024-01-03T00:00:00Z",
                 "2024-01-03T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
         // Should return newest first
-        let results = db.list_since("proj1", "2023-12-31T00:00:00Z", 10).unwrap();
+        let results = db.list_since("proj1", "2023-12-31T00:00:00Z", 10, None, None).unwrap();
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].id, id3);
         assert_eq!(results[1].id, id2);
@@ -149,8 +163,8 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
 
-        let id1 = db.insert("proj1", "content 1", &embedding, None).unwrap();
-        let id2 = db.insert("proj1", "content 2", &embedding, None).unwrap();
+        let id1 = db.insert("proj1", "content 1", &embedding, None, "fact", "active").unwrap();
+        let id2 = db.insert("proj1", "content 2", &embedding, None, "fact", "active").unwrap();
 
         let results = db.get_many(&[&id1, &id2]).unwrap();
         assert_eq!(results.len(), 2);
@@ -165,9 +179,9 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
 
-        let id1 = db.insert("proj1", "first", &embedding, None).unwrap();
-        let id2 = db.insert("proj1", "second", &embedding, None).unwrap();
-        let id3 = db.insert("proj1", "third", &embedding, None).unwrap();
+        let id1 = db.insert("proj1", "first", &embedding, None, "fact", "active").unwrap();
+        let id2 = db.insert("proj1", "second", &embedding, None, "fact", "active").unwrap();
+        let id3 = db.insert("proj1", "third", &embedding, None, "fact", "active").unwrap();
 
         // Query in reverse order
         let results = db.get_many(&[&id3, &id1, &id2]).unwrap();
@@ -181,8 +195,8 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
 
-        let id1 = db.insert("proj1", "content 1", &embedding, None).unwrap();
-        let id2 = db.insert("proj1", "content 2", &embedding, None).unwrap();
+        let id1 = db.insert("proj1", "content 1", &embedding, None, "fact", "active").unwrap();
+        let id2 = db.insert("proj1", "content 2", &embedding, None, "fact", "active").unwrap();
 
         // Mix of valid and invalid IDs
         let results = db
@@ -219,7 +233,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
 
-        let id = db.insert("proj1", "content", &embedding, None).unwrap();
+        let id = db.insert("proj1", "content", &embedding, None, "fact", "active").unwrap();
 
         let results = db.get_many(&[&id]).unwrap();
         assert_eq!(results.len(), 1);
@@ -233,8 +247,8 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
 
-        let id1 = db.insert("proj1", "content 1", &embedding, None).unwrap();
-        let id2 = db.insert("proj1", "content 2", &embedding, None).unwrap();
+        let id1 = db.insert("proj1", "content 1", &embedding, None, "fact", "active").unwrap();
+        let id2 = db.insert("proj1", "content 2", &embedding, None, "fact", "active").unwrap();
 
         // Query with duplicate IDs
         let results = db.get_many(&[&id1, &id2, &id1, &id2]).unwrap();
@@ -262,6 +276,8 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let _id2 = db
@@ -272,13 +288,15 @@ mod tests {
                 None,
                 "2024-01-02T00:00:00Z",
                 "2024-01-02T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
         // Query with UTC+01:00 offset works (RFC3339 parsing succeeds)
         // SQLite compares as strings: "2024-01-02T00:00:00Z" > "2024-01-01T11:00:00+01:00"
         let results = db
-            .list_since("proj1", "2024-01-01T11:00:00+01:00", 10)
+            .list_since("proj1", "2024-01-01T11:00:00+01:00", 10, None, None)
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].content, "new");
@@ -286,15 +304,15 @@ mod tests {
         // Query with UTC-05:00 offset also works
         // SQLite compares as strings: "2024-01-02T00:00:00Z" > "2024-01-01T19:00:00-05:00"
         let results = db
-            .list_since("proj1", "2024-01-01T19:00:00-05:00", 10)
+            .list_since("proj1", "2024-01-01T19:00:00-05:00", 10, None, None)
             .unwrap();
         // String comparison: "2024-01-02..." is lexicographically greater than "2024-01-01..."
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].content, "new");
 
-        // Query after the stored timestamp returns nothing (exclusive bound)
+        // Query after the stored timestamp returns nothing (Exclusive bound)
         // SQLite string comparison: "2024-01-02T00:00:00Z" is NOT > "2024-01-02T00:00:00Z"
-        let results = db.list_since("proj1", "2024-01-02T00:00:00Z", 10).unwrap();
+        let results = db.list_since("proj1", "2024-01-02T00:00:00Z", 10, None, None).unwrap();
         assert_eq!(results.len(), 0);
     }
 
@@ -312,13 +330,15 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
         // Query with and without fractional seconds - should behave identically
-        let results1 = db.list_since("proj1", "2023-12-31T23:59:59Z", 10).unwrap();
+        let results1 = db.list_since("proj1", "2023-12-31T23:59:59Z", 10, None, None).unwrap();
         let results2 = db
-            .list_since("proj1", "2023-12-31T23:59:59.000Z", 10)
+            .list_since("proj1", "2023-12-31T23:59:59.000Z", 10, None, None)
             .unwrap();
 
         assert_eq!(results1.len(), results2.len());
@@ -328,7 +348,7 @@ mod tests {
 
         // Precision equivalence with milliseconds
         let results3 = db
-            .list_since("proj1", "2023-12-31T23:59:59.999Z", 10)
+            .list_since("proj1", "2023-12-31T23:59:59.999Z", 10, None, None)
             .unwrap();
         // Should include the memory since it's before the timestamp
         assert_eq!(results3.len(), 1);
@@ -341,29 +361,29 @@ mod tests {
         let embedding = vec![0.1f32; 384];
 
         // Insert multiple memories
-        let id1 = db.insert("proj1", "first", &embedding, None).unwrap();
-        let id2 = db.insert("proj1", "second", &embedding, None).unwrap();
-        let id3 = db.insert("proj1", "third", &embedding, None).unwrap();
+        let id1 = db.insert("proj1", "first", &embedding, None, "fact", "active").unwrap();
+        let id2 = db.insert("proj1", "second", &embedding, None, "fact", "active").unwrap();
+        let id3 = db.insert("proj1", "third", &embedding, None, "fact", "active").unwrap();
 
         // Test ordering (newest first)
-        let results = db.list("proj1", 10).unwrap();
+        let results = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].id, id3);
         assert_eq!(results[1].id, id2);
         assert_eq!(results[2].id, id1);
 
         // Test limit
-        let results = db.list("proj1", 2).unwrap();
+        let results = db.list("proj1", 2, None, None).unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].id, id3);
 
         // Test project isolation
-        db.insert("proj2", "other", &embedding, None).unwrap();
-        let proj1_results = db.list("proj1", 10).unwrap();
+        db.insert("proj2", "other", &embedding, None, "fact", "active").unwrap();
+        let proj1_results = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(proj1_results.len(), 3);
 
         // Test empty project
-        let empty_results = db.list("nonexistent", 10).unwrap();
+        let empty_results = db.list("nonexistent", 10, None, None).unwrap();
         assert_eq!(empty_results.len(), 0);
     }
 
@@ -372,7 +392,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         let id = db
-            .insert("proj1", "test content", &embedding, None)
+            .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         let memory = db.get(&id).unwrap();
@@ -392,6 +412,8 @@ mod tests {
                 "test content",
                 &embedding,
                 Some(r#"{"key": "value"}"#),
+                "fact",
+                "active",
             )
             .unwrap();
 
@@ -403,7 +425,7 @@ mod tests {
     fn test_insert_invalid_embedding() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 256];
-        let result = db.insert("proj1", "test", &embedding, None);
+        let result = db.insert("proj1", "test", &embedding, None, "fact", "active");
         assert!(result.is_err());
     }
 
@@ -426,6 +448,8 @@ mod tests {
                 None,
                 "2024-01-01T00:00:00Z",
                 "2024-01-01T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
         let id2 = db
@@ -436,10 +460,12 @@ mod tests {
                 None,
                 "2024-01-02T00:00:00Z",
                 "2024-01-02T00:00:00Z",
+                "fact",
+                "active",
             )
             .unwrap();
 
-        let memories = db.list("proj1", 10).unwrap();
+        let memories = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(memories.len(), 2);
         assert_eq!(memories[0].id, id2); // Newest first
         assert_eq!(memories[1].id, id1);
@@ -450,11 +476,11 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
         for i in 0..5 {
-            db.insert("proj1", &format!("content {}", i), &embedding, None)
+            db.insert("proj1", &format!("content {}", i), &embedding, None, "fact", "active")
                 .unwrap();
         }
 
-        let memories = db.list("proj1", 2).unwrap();
+        let memories = db.list("proj1", 2, None, None).unwrap();
         assert_eq!(memories.len(), 2);
     }
 
@@ -462,7 +488,7 @@ mod tests {
     fn test_update() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "original", &embedding, None).unwrap();
+        let id = db.insert("proj1", "original", &embedding, None, "fact", "active").unwrap();
 
         db.update(&id, Some("updated"), Some(&embedding), None).unwrap();
 
@@ -482,7 +508,7 @@ mod tests {
     fn test_delete() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        let id = db.insert("proj1", "content", &embedding, None).unwrap();
+        let id = db.insert("proj1", "content", &embedding, None, "fact", "active").unwrap();
 
         let deleted = db.delete(&id).unwrap();
         assert!(deleted);
@@ -502,13 +528,13 @@ mod tests {
     fn test_project_isolation() {
         let db = create_test_db();
         let embedding = vec![0.1f32; 384];
-        db.insert("proj1", "proj1 content", &embedding, None)
+        db.insert("proj1", "proj1 content", &embedding, None, "fact", "active")
             .unwrap();
-        db.insert("proj2", "proj2 content", &embedding, None)
+        db.insert("proj2", "proj2 content", &embedding, None, "fact", "active")
             .unwrap();
 
-        let list1 = db.list("proj1", 10).unwrap();
-        let list2 = db.list("proj2", 10).unwrap();
+        let list1 = db.list("proj1", 10, None, None).unwrap();
+        let list2 = db.list("proj2", 10, None, None).unwrap();
 
         assert_eq!(list1.len(), 1);
         assert_eq!(list2.len(), 1);
@@ -521,7 +547,7 @@ mod tests {
         let db = create_test_db();
         let embedding = vec![0.1f32; EMBEDDING_DIMS];
         let id = db
-            .insert("proj1", "test content", &embedding, None)
+            .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
         let memory = db.get(&id).unwrap().unwrap();
@@ -537,10 +563,10 @@ mod tests {
         let embedding1 = vec![0.1f32; EMBEDDING_DIMS];
         let embedding2 = vec![0.2f32; EMBEDDING_DIMS];
 
-        db.insert("proj1", "first", &embedding1, None).unwrap();
-        db.insert("proj1", "second", &embedding2, None).unwrap();
+        db.insert("proj1", "first", &embedding1, None, "fact", "active").unwrap();
+        db.insert("proj1", "second", &embedding2, None, "fact", "active").unwrap();
 
-        let memories = db.list("proj1", 10).unwrap();
+        let memories = db.list("proj1", 10, None, None).unwrap();
         assert_eq!(memories.len(), 2);
 
         for memory in &memories {
@@ -557,7 +583,9 @@ mod tests {
         full_embedding[1] = original[1];
         full_embedding[EMBEDDING_DIMS - 1] = original[2];
 
-        let id = db.insert("proj1", "test", &full_embedding, None).unwrap();
+        let id = db
+            .insert("proj1", "test", &full_embedding, None, "fact", "active")
+            .unwrap();
 
         let memory = db.get(&id).unwrap().unwrap();
         assert_eq!(memory.embedding.len(), EMBEDDING_DIMS);

--- a/tests/lib_integration.rs
+++ b/tests/lib_integration.rs
@@ -22,7 +22,14 @@ fn test_memory_store_add_then_search_returns_matching_memory() {
     // Add a memory
     let project_id = "test-project";
     let memory_id = match store
-        .add_with_conflict(project_id, "Alice works at Microsoft", None, false)
+        .add_with_conflict(
+            project_id,
+            "Alice works at Microsoft",
+            None,
+            false,
+            "fact",
+            "active",
+        )
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -33,7 +40,7 @@ fn test_memory_store_add_then_search_returns_matching_memory() {
 
     // Search for the memory
     let results = store
-        .search(project_id, "where does alice work", 10, 0.0)
+        .search(project_id, "where does alice work", 10, 0.0, None, None)
         .expect("Failed to search");
 
     assert_eq!(results.len(), 1);
@@ -67,7 +74,7 @@ fn test_add_with_empty_input_returns_error() {
     let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
         .expect("Failed to create store");
 
-    let result = store.add_with_conflict("test", "", None, false);
+    let result = store.add_with_conflict("test", "", None, false, "fact", "active");
     assert!(result.is_err());
     if !matches!(result.as_ref().unwrap_err(), Error::EmptyInput) {
         panic!("Expected EmptyInput error");
@@ -88,7 +95,7 @@ fn test_add_with_oversized_input_returns_error() {
 
     // Create input longer than MAX_INPUT_LENGTH
     let long_text = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.add_with_conflict("test", &long_text, None, false);
+    let result = store.add_with_conflict("test", &long_text, None, false, "fact", "active");
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -114,7 +121,7 @@ fn test_search_with_empty_input_returns_error() {
     let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
         .expect("Failed to create store");
 
-    let result = store.search("test", "", 10, 0.0);
+    let result = store.search("test", "", 10, 0.0, None, None);
     assert!(result.is_err());
     if !matches!(result.as_ref().unwrap_err(), Error::EmptyInput) {
         panic!("Expected EmptyInput error");
@@ -135,7 +142,7 @@ fn test_search_with_oversized_input_returns_error() {
 
     // Create input longer than MAX_INPUT_LENGTH
     let long_query = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.search("test", &long_query, 10, 0.0);
+    let result = store.search("test", &long_query, 10, 0.0, None, None);
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -200,6 +207,8 @@ fn test_memory_with_stored_content_returns_expected_fields() {
             "Test content",
             Some(r#"{"key": "value"}"#),
             false,
+            "fact",
+            "active",
         )
         .expect("Failed to add memory")
     {
@@ -239,14 +248,28 @@ fn test_search_hybrid_with_test_memories_returns_fused_results() {
 
     // Add multiple memories
     match store
-        .add_with_conflict(project_id, "Authentication uses JWT tokens", None, false)
+        .add_with_conflict(
+            project_id,
+            "Authentication uses JWT tokens",
+            None,
+            false,
+            "fact",
+            "active",
+        )
         .expect("Failed to add memory 1")
     {
         vipune::AddResult::Added { .. } => {}
         _ => panic!("Expected AddResult::Added"),
     }
     match store
-        .add_with_conflict(project_id, "User management system", None, false)
+        .add_with_conflict(
+            project_id,
+            "User management system",
+            None,
+            false,
+            "fact",
+            "active",
+        )
         .expect("Failed to add memory 2")
     {
         vipune::AddResult::Added { .. } => {}
@@ -255,7 +278,7 @@ fn test_search_hybrid_with_test_memories_returns_fused_results() {
 
     // Search using hybrid
     let results = store
-        .search_hybrid(project_id, "auth token", 10, 0.0)
+        .search_hybrid(project_id, "auth token", 10, 0.0, None, None)
         .expect("Failed to search hybrid");
 
     assert!(!results.is_empty());
@@ -275,7 +298,7 @@ fn test_update_with_empty_input_returns_error() {
         .expect("Failed to create store");
 
     let memory_id = match store
-        .add_with_conflict("test", "Original content", None, false)
+        .add_with_conflict("test", "Original content", None, false, "fact", "active")
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -303,7 +326,7 @@ fn test_update_with_oversized_input_returns_error() {
         .expect("Failed to create store");
 
     let memory_id = match store
-        .add_with_conflict("test", "Original content", None, false)
+        .add_with_conflict("test", "Original content", None, false, "fact", "active")
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -339,7 +362,7 @@ fn test_search_with_zero_limit_returns_error() {
         .expect("Failed to create store");
 
     // Try to search with limit=0
-    let result = store.search("test", "query", 0, 0.0);
+    let result = store.search("test", "query", 0, 0.0, None, None);
     assert!(result.is_err());
     if let Error::InvalidInput(msg) = &result.as_ref().unwrap_err() {
         assert!(msg.contains("Limit must be greater than 0"));
@@ -361,7 +384,7 @@ fn test_search_with_limit_over_max_returns_error() {
         .expect("Failed to create store");
 
     // Try to search with excessively large limit
-    let result = store.search("test", "query", 10_001, 0.0);
+    let result = store.search("test", "query", 10_001, 0.0, None, None);
     assert!(result.is_err());
     if let Error::InvalidInput(msg) = &result.as_ref().unwrap_err() {
         assert!(msg.contains("exceeds maximum allowed"));
@@ -383,12 +406,12 @@ fn test_add_with_whitespace_only_input_returns_error() {
         .expect("Failed to create store");
 
     // Try to add whitespace-only content
-    let result = store.add_with_conflict("test", "   ", None, false);
+    let result = store.add_with_conflict("test", "   ", None, false, "fact", "active");
     assert!(result.is_err());
     assert!(matches!(result.as_ref().unwrap_err(), Error::EmptyInput));
 
     // Try to search with whitespace-only query
-    let result = store.search("test", "\t\n", 10, 0.0);
+    let result = store.search("test", "\t\n", 10, 0.0, None, None);
     assert!(result.is_err());
     assert!(matches!(result.as_ref().unwrap_err(), Error::EmptyInput));
 
@@ -475,7 +498,7 @@ fn test_list_with_zero_limit_returns_error() {
         .expect("Failed to create store");
 
     // Try to list with limit=0
-    let result = store.list("test", 0);
+    let result = store.list("test", 0, None, None);
     assert!(result.is_err());
     if let Error::InvalidInput(msg) = &result.as_ref().unwrap_err() {
         assert!(msg.contains("Limit must be greater than 0"));
@@ -497,7 +520,7 @@ fn test_list_with_limit_over_max_returns_error() {
         .expect("Failed to create store");
 
     // Try to list with excessively large limit
-    let result = store.list("test", 10_001);
+    let result = store.list("test", 10_001, None, None);
     assert!(result.is_err());
     if let Error::InvalidInput(msg) = &result.as_ref().unwrap_err() {
         assert!(msg.contains("exceeds maximum allowed"));
@@ -522,37 +545,50 @@ fn test_list_regression_coverage() {
 
     // Add multiple memories
     let _id1 = store
-        .add_with_conflict(project_id, "first memory", None, true)
+        .add_with_conflict(project_id, "first memory", None, true, "fact", "active")
         .expect("Failed to add memory");
     let _id2 = store
-        .add_with_conflict(project_id, "second memory", None, true)
+        .add_with_conflict(project_id, "second memory", None, true, "fact", "active")
         .expect("Failed to add memory");
     let _id3 = store
-        .add_with_conflict(project_id, "third memory", None, true)
+        .add_with_conflict(project_id, "third memory", None, true, "fact", "active")
         .expect("Failed to add memory");
 
     // Test ordering (newest first)
-    let results = store.list(project_id, 10).expect("Failed to list");
+    let results = store
+        .list(project_id, 10, None, None)
+        .expect("Failed to list");
     assert_eq!(results.len(), 3);
     assert_eq!(results[0].content, "third memory");
     assert_eq!(results[1].content, "second memory");
     assert_eq!(results[2].content, "first memory");
 
     // Test limit
-    let results = store.list(project_id, 2).expect("Failed to list");
+    let results = store
+        .list(project_id, 2, None, None)
+        .expect("Failed to list");
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].content, "third memory");
 
     // Test project isolation
     let _id4 = store
-        .add_with_conflict("other-project", "other memory", None, true)
+        .add_with_conflict(
+            "other-project",
+            "other memory",
+            None,
+            true,
+            "fact",
+            "active",
+        )
         .expect("Failed to add memory");
-    let project1_results = store.list(project_id, 10).expect("Failed to list");
+    let project1_results = store
+        .list(project_id, 10, None, None)
+        .expect("Failed to list");
     assert_eq!(project1_results.len(), 3);
 
     // Test empty project
     let empty_results = store
-        .list("nonexistent_project", 10)
+        .list("nonexistent_project", 10, None, None)
         .expect("Failed to list");
     assert_eq!(empty_results.len(), 0);
 
@@ -573,21 +609,21 @@ fn test_list_since_with_timezone_offset() {
 
     // Add memories with controlled timestamps
     let _old = store
-        .add_with_conflict(project_id, "old memory", None, true)
+        .add_with_conflict(project_id, "old memory", None, true, "fact", "active")
         .expect("Failed to add memory");
 
     // Wait at least 1ms to ensure different timestamps
     std::thread::sleep(std::time::Duration::from_millis(10));
 
     let _new = store
-        .add_with_conflict(project_id, "new memory", None, true)
+        .add_with_conflict(project_id, "new memory", None, true, "fact", "active")
         .expect("Failed to add memory");
 
     // Test with UTC timestamp (should succeed and only return newer)
     let now = chrono::Utc::now();
     let one_minute_ago = (now - chrono::Duration::minutes(1)).to_rfc3339();
     let results = store
-        .list_since(project_id, &one_minute_ago, 10)
+        .list_since(project_id, &one_minute_ago, 10, None, None)
         .expect("Failed to list");
     // Should only return "new memory" as it's more recent than one minute ago
     assert!(results.len() >= 1);
@@ -609,7 +645,7 @@ fn test_list_since_timestamp_precision_equivalence() {
     let project_id = "test-project";
 
     let _id = store
-        .add_with_conflict(project_id, "test memory", None, true)
+        .add_with_conflict(project_id, "test memory", None, true, "fact", "active")
         .expect("Failed to add memory");
 
     // Wait to ensure timestamp difference
@@ -620,11 +656,11 @@ fn test_list_since_timestamp_precision_equivalence() {
     let two_seconds_ago = (now - chrono::Duration::seconds(2)).to_rfc3339();
 
     let results1 = store
-        .list_since(project_id, &two_seconds_ago, 10)
+        .list_since(project_id, &two_seconds_ago, 10, None, None)
         .expect("Failed to list");
 
     let results2 = store
-        .list_since(project_id, &two_seconds_ago, 10)
+        .list_since(project_id, &two_seconds_ago, 10, None, None)
         .expect("Failed to list");
 
     // Results should be identical (same query, same results)
@@ -649,7 +685,7 @@ fn test_get_many_with_duplicate_ids() {
     let project_id = "test-project";
 
     let id1 = match store
-        .add_with_conflict(project_id, "first", None, true)
+        .add_with_conflict(project_id, "first", None, true, "fact", "active")
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -657,7 +693,7 @@ fn test_get_many_with_duplicate_ids() {
     };
 
     let id2 = match store
-        .add_with_conflict(project_id, "second", None, true)
+        .add_with_conflict(project_id, "second", None, true, "fact", "active")
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -689,7 +725,7 @@ fn test_add_at_exactly_max_input_length_returns_success() {
 
     // Create input exactly at MAX_INPUT_LENGTH
     let exact_text = "x".repeat(MAX_INPUT_LENGTH);
-    let result = store.add_with_conflict("test", &exact_text, None, false);
+    let result = store.add_with_conflict("test", &exact_text, None, false, "fact", "active");
     assert!(
         result.is_ok(),
         "Should accept input at exactly MAX_INPUT_LENGTH"
@@ -710,7 +746,7 @@ fn test_add_one_over_max_input_length_returns_error() {
 
     // Create input one character over MAX_INPUT_LENGTH
     let too_long_text = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.add_with_conflict("test", &too_long_text, None, false);
+    let result = store.add_with_conflict("test", &too_long_text, None, false, "fact", "active");
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -736,7 +772,7 @@ fn test_search_hybrid_with_empty_input_returns_error() {
     let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
         .expect("Failed to create store");
 
-    let result = store.search_hybrid("test", "", 10, 0.0);
+    let result = store.search_hybrid("test", "", 10, 0.0, None, None);
     assert!(result.is_err());
     assert!(matches!(result.as_ref().unwrap_err(), Error::EmptyInput));
 
@@ -754,7 +790,7 @@ fn test_search_hybrid_with_oversized_input_returns_error() {
         .expect("Failed to create store");
 
     let long_query = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.search_hybrid("test", &long_query, 10, 0.0);
+    let result = store.search_hybrid("test", &long_query, 10, 0.0, None, None);
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -854,7 +890,9 @@ fn test_ingest_force_policy_bypasses_conflicts() {
     };
 
     // Verify both memories exist
-    let results = store.list(project_id, 10).expect("Failed to list memories");
+    let results = store
+        .list(project_id, 10, None, None)
+        .expect("Failed to list memories");
     assert_eq!(
         results.len(),
         2,
@@ -1005,6 +1043,8 @@ fn test_update_text_only_preserves_metadata() {
             "original content",
             Some(r#"{"tag": "important"}"#),
             true,
+            "fact",
+            "active",
         )
         .expect("Failed to add")
     {
@@ -1039,7 +1079,7 @@ fn test_update_with_invalid_json_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true)
+        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1078,7 +1118,7 @@ fn test_update_with_empty_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true)
+        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1117,7 +1157,7 @@ fn test_update_with_whitespace_only_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true)
+        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1156,7 +1196,7 @@ fn test_update_metadata_only() {
 
     // Add memory without metadata
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true)
+        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1190,7 +1230,14 @@ fn test_update_both_text_and_metadata() {
 
     // Add memory with old metadata
     let id = match store
-        .add_with_conflict(project_id, "old content", Some(r#"{"old": "value"}"#), true)
+        .add_with_conflict(
+            project_id,
+            "old content",
+            Some(r#"{"old": "value"}"#),
+            true,
+            "fact",
+            "active",
+        )
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,


### PR DESCRIPTION
## Summary

Adds memory lifecycle management to vipune — the final implementation issue for v0.3.0.

### Changes

- **MemoryType enum** (fact/preference/procedure/guard/observation) — routing, not classification
- **MemoryStatus enum** (active/candidate/superseded/deprecated) — lifecycle tracking
- **--supersedes flag** — atomic replacement: inserts new memory + marks old as superseded in one transaction
- **Filters** — --memory-type and --status on search/list; --include-candidates shorthand
- **Default behavior** — search and list return only active memories (backward compatible)
- **Migration v2** — adds type, status, superseded_by columns with indexes to SQLite schema
- **MCP tools** — accept optional memory_types and statuses filter parameters

### Quality Gates

- cargo fmt --check ✅
- cargo clippy -- -D warnings ✅
- cargo test (182 tests) ✅
- cargo test --no-default-features (172 tests) ✅
- Adversarial review: APPROVED ✅

Fixes #89