### PR TITLE
docs(#96): update documentation for v0.3 API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,13 @@ vipune add "Auth uses JWT tokens" --metadata '{"topic": "authentication"}'
 
 | Command | Description |
 |---------|-------------|
-| `vipune add <text>` | Store a memory |
-| `vipune search <query>` | Find memories by meaning |
+| `vipune add <text>` | Store a memory (with type, status, conflict detection) |
+| `vipune search <query>` | Find memories by meaning (filters by type/status) |
 | `vipune get <id>` | Retrieve a memory by ID |
-| `vipune list` | List all memories |
+| `vipune list` | List memories (default: active only) |
 | `vipune delete <id>` | Delete a memory |
-| `vipune update <id> <text>` | Update a memory's content |
+| `vipune update <id> [text]` | Update content, metadata, type, or status |
+| `vipune validate <text>` | Check if text is within embedding token limits |
 | `vipune version` | Show version |
 
 [Complete CLI reference](docs/cli-reference.md) • [Quickstart guide](docs/quickstart.md) • [Search guide](docs/search.md) • [Architecture](docs/architecture.md)
@@ -197,7 +198,7 @@ vipune can also be used as a Rust crate for programmatic integration:
 ```toml
 # Cargo.toml
 [dependencies]
-vipune = "0.2"
+vipune = "0.3"
 ```
 
 ```rust
@@ -217,13 +218,15 @@ let memory_id = store.add(&project_id, "Alice works at Microsoft", None)
     .expect("Failed to add memory");
 
 // Search memories
-let results = store.search(&project_id, "where does alice work", 10, 0.0)
+let results = store.search(&project_id, "where does alice work", 10, 0.0, None, None)
     .expect("Failed to search");
 
 for memory in results {
     println!("{:.2}: {}", memory.similarity.unwrap_or(0.0), memory.content);
 }
 ```
+
+**v0.3 additions**: `MemoryType`, `MemoryStatus`, and filter parameters are available for type-aware memory management. See the [CLI reference](docs/cli-reference.md) for details.
 
 **See the crate documentation at [docs.rs](https://docs.rs/vipune) for complete API reference.**
 
@@ -296,6 +299,7 @@ vipune works with any agent that can run shell commands — no plugins, adapters
 - `0` - Success
 - `1` - Error (missing file, invalid input, etc.)
 - `2` - Conflicts detected (similar memories found)
+- `3` - Content too long (exceeds embedding token limit)
 
 ## Recency Scoring
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -14,6 +14,28 @@ Use vipune to create a feedback cycle in your agent workflow:
 2. **Do the work** - Execute your task with the knowledge in mind
 3. **Store learnings** - `vipune add "important discovery"` after completing meaningful work
 
+### v0.3 memory types
+
+Memories can be categorized by type for routing and filtering:
+
+```bash
+# Store a guard (safety constraint)
+vipune add "Never deploy on Fridays" --memory-type guard
+
+# Store a procedure
+vipune add "Run cargo test before pushing" --memory-type procedure
+
+# Search only guard memories
+vipune search "deployment rules" --memory-type guard
+
+# Replace an outdated memory
+vipune add "Alice now works at Google" --supersedes <old-memory-id>
+```
+
+Available types: `fact` (default), `preference`, `procedure`, `guard`, `observation`
+
+Default search returns only `active` memories. Use `--include-candidates` to also see `candidate` memories.
+
 This pattern is especially useful for:
 - Avoiding duplicate implementations or analyses
 - Maintaining architectural consistency across multiple tasks

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,7 @@ These flags apply to all commands:
 Store a memory.
 
 ```
-vipune add <text> [--metadata <json>] [--force]
+vipune add <text> [--metadata <json>] [--force] [--memory-type <type>] [--status <status>] [--supersedes <id>]
 ```
 
 **Arguments:**
@@ -28,17 +28,22 @@ vipune add <text> [--metadata <json>] [--force]
 **Flags:**
 - `-m, --metadata <json>` - Optional JSON metadata (e.g., `{"topic": "auth"}`)
 - `--force` - Bypass conflict detection and add regardless
+- `--memory-type <type>` - Memory type: `fact` (default), `preference`, `procedure`, `guard`, `observation`
+- `--status <status>` - Initial status: `active` (default) or `candidate`
+- `--supersedes <id>` - Atomically supersede an existing memory (mutually exclusive with `--force`)
 
 **Behavior:**
 - Generates semantic embedding for the text
 - Checks for similar existing memories (similarity ≥ threshold)
 - If conflicts found: returns exit code 2, lists conflicting memories
 - If `--force` used: skips conflict check and adds memory
+- If `--supersedes` used: atomically adds new memory and marks target as `superseded`
 
 **Exit codes:**
 - `0` - Successfully added
 - `1` - Error (invalid input, database error)
 - `2` - Conflicts detected (similar memories exist)
+- `3` - Content too long (exceeds embedding token limit)
 
 **Human output:**
 ```
@@ -77,6 +82,13 @@ Use --force to add anyway
 }
 ```
 
+**Supersede example:**
+```bash
+# Replace an outdated memory atomically
+vipune add "Alice now works at Google" --supersedes abc123-old-memory-id
+```
+This inserts the new memory and marks the old one as `superseded` in a single transaction.
+
 ---
 
 ### search
@@ -84,7 +96,7 @@ Use --force to add anyway
 Find memories by semantic similarity.
 
 ```
-vipune search <query> [--limit <n>] [--recency <weight>] [--hybrid]
+vipune search <query> [--limit <n>] [--recency <weight>] [--hybrid] [--memory-type <types>] [--status <statuses>] [--include-candidates]
 ```
 
 **Arguments:**
@@ -94,6 +106,9 @@ vipune search <query> [--limit <n>] [--recency <weight>] [--hybrid]
 - `-l, --limit <n>` - Maximum results to return (default: `5`)
 - `--recency <weight>` - Recency bias for scoring, 0.0 to 1.0 (default: from config, typically `0.3`)
 - `--hybrid` - Enables hybrid search combining semantic similarity with FTS5 full-text search using Reciprocal Rank Fusion (RRF)
+- `--memory-type <types>` - Filter by memory type (comma-separated, e.g., `guard,procedure`)
+- `--status <statuses>` - Filter by status (comma-separated, e.g., `active,candidate`)
+- `--include-candidates` - Shorthand to include both `active` and `candidate` memories
 
 **Behavior:**
 - Generates embedding for query
@@ -101,6 +116,7 @@ vipune search <query> [--limit <n>] [--recency <weight>] [--hybrid]
 - Combines semantic similarity with time decay for final score
 - Returns results sorted by final score (highest first)
 - All memories in current project scope
+- **Default filtering:** Only `active` memories are returned by default. Use `--status` or `--include-candidates` to include other statuses.
 
 **Recency scoring:**
 The final score combines: `(1 - recency_weight) * similarity + recency_weight * time_score`
@@ -198,15 +214,19 @@ Updated: 2024-01-15T10:30:00Z
 List all memories in the current project.
 
 ```
-vipune list [--limit <n>]
+vipune list [--limit <n>] [--memory-type <types>] [--status <statuses>] [--include-candidates]
 ```
 
 **Flags:**
 - `-l, --limit <n>` - Maximum results to return (default: `10`)
+- `--memory-type <types>` - Filter by memory type (comma-separated, e.g., `guard,procedure`)
+- `--status <statuses>` - Filter by status (comma-separated, e.g., `active,candidate`)
+- `--include-candidates` - Shorthand to include both `active` and `candidate` memories
 
 **Behavior:**
 - Returns memories ordered by creation time (newest first)
 - Limited to current project scope
+- **Default filtering:** Only `active` memories are returned by default. Use `--status` or `--include-candidates` to include other statuses.
 
 **Exit codes:**
 - `0` - Success (may return empty list)
@@ -272,17 +292,21 @@ Deleted memory: 123e4567-e89b-12d3-a456-426614174000
 Update a memory's content.
 
 ```
-vipune update <id> <text>
+vipune update <id> [text] [--metadata <json>]
 ```
 
 **Arguments:**
 - `id` - Memory ID (required)
-- `text` - New content (required)
+- `text` - New content (optional — if omitted, only metadata is updated)
+
+**Flags:**
+- `-m, --metadata <json>` - Replace metadata (must be valid JSON)
 
 **Behavior:**
-- Generates new embedding for updated content
-- Preserves: ID, project ID, creation timestamp
-- Updates: content, embedding, updated_at timestamp
+- If only `text` provided: generates new embedding, preserves metadata
+- If only `--metadata` provided: updates metadata without re-embedding
+- If both `text` and `--metadata` provided: updates both
+- Metadata must be valid JSON (validated on write)
 
 **Exit codes:**
 - `0` - Memory updated
@@ -298,6 +322,37 @@ Updated memory: 123e4567-e89b-12d3-a456-426614174000
 {
   "status": "updated",
   "id": "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+---
+
+### validate
+
+Check if text content is within the embedding model's token limit.
+
+```
+vipune validate <text>
+```
+
+**Arguments:**
+- `text` - Text to validate (required)
+
+**Exit codes:**
+- `0` - Within token limit
+- `3` - Content exceeds token limit
+
+**Human output:**
+```
+Token count: 42/512 — within limit
+```
+
+**JSON output:**
+```json
+{
+  "token_count": 42,
+  "max_tokens": 512,
+  "within_limit": true
 }
 ```
 
@@ -350,12 +405,24 @@ vipune mcp
 | Tool | Description |
 |------|-------------|
 | `store_memory` | Store information for later recall |
-| `search_memories` | Find memories by meaning |
-| `list_memories` | List recent memories |
+| `search_memories` | Find memories by meaning, with type/status filters |
+| `list_memories` | List recent memories, with type/status filters |
 
 **Exit codes:**
 - `0` - Success
 - `1` - Error (initialization failed)
+
+**New v0.3 tool parameters:**
+
+`store_memory` accepts:
+- `text` — the information to remember (required)
+- `metadata` — optional structured labels as JSON (e.g., `{"topic": "auth"}`)
+
+Note: Memory type, status, and supersede are available via CLI but not yet exposed in the MCP `store_memory` tool.
+
+`search_memories` and `list_memories` accept optional:
+- `memory_types` — array of types to filter by (e.g., `["guard", "procedure"]`)
+- `status` — array of statuses to filter by (e.g., `["active", "candidate"]`)
 
 **Example MCP configuration (Claude Code):**
 ```json
@@ -368,6 +435,25 @@ vipune mcp
   }
 }
 ```
+
+---
+
+## Upgrading from v0.2
+
+v0.3 includes automatic schema migrations — no manual steps required. On first run after upgrading, vipune will add the new `type`, `status`, and `superseded_by` columns to your existing database. All existing memories default to type `fact` and status `active`.
+
+**Breaking change:** Content that previously was silently truncated when exceeding the embedding token limit now fails with exit code 3. Use `vipune validate <text>` to check content length before adding.
+
+---
+
+## Exit Codes Summary
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Error (invalid input, database error, not found) |
+| `2` | Conflicts detected (similar memories exist) |
+| `3` | Content too long (exceeds embedding token limit) |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all user-facing documentation for v0.3 API changes across issues #86, #87, #88, #89, #90.

### Files Changed

- **README.md** — CLI table (new validate command, updated descriptions), library usage v0.3, exit code 3
- **docs/cli-reference.md** — New flags (--memory-type, --status, --supersedes, --include-candidates), validate command, MCP v0.3 params, upgrading guide, exit codes table
- **docs/agent-integration.md** — v0.3 memory types section with examples

### Quality Gates

- cargo fmt --check ✅
- cargo clippy -- -D warnings ✅
- cargo test (182 tests) ✅
- Adversarial review: APPROVED ✅

Fixes #96