### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-28
+
+
 ## [0.3.0] - 2026-04-27
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,7 +2191,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vipune"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vipune"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vipune`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `vipune` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.hybrid in /tmp/.tmpAJoGpM/vipune/src/config/mod.rs:58
  field Config.hybrid in /tmp/.tmpAJoGpM/vipune/src/config/mod.rs:58

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vipune::mcp::tools::ToolHandler::new now takes 3 parameters instead of 2, in /tmp/.tmpAJoGpM/vipune/src/mcp/tools.rs:315
  vipune::memory::MemoryStore::update now takes 5 parameters instead of 3, in /tmp/.tmpAJoGpM/vipune/src/memory/crud.rs:260
  vipune::MemoryStore::update now takes 5 parameters instead of 3, in /tmp/.tmpAJoGpM/vipune/src/memory/crud.rs:260
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).