### PR TITLE
docs(#112): fix documentation drift from v0.3.1 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ vipune can also be used as a Rust crate for programmatic integration:
 ```toml
 # Cargo.toml
 [dependencies]
-vipune = "0.3"
+vipune = "0.3.0"
 ```
 
 ```rust
@@ -226,7 +226,7 @@ for memory in results {
 }
 ```
 
-**v0.3 additions**: `MemoryType`, `MemoryStatus`, and filter parameters are available for type-aware memory management. See the [CLI reference](docs/cli-reference.md) for details.
+**v0.3 features**: `MemoryType`, `MemoryStatus`, `supersedes` flag, and filter parameters are available for type-aware memory management. See the [CLI reference](docs/cli-reference.md) for details.
 
 **See the crate documentation at [docs.rs](https://docs.rs/vipune) for complete API reference.**
 
@@ -246,6 +246,7 @@ vipune works with zero configuration. All paths use the user's home directory:
 - `VIPUNE_PROJECT` - Project identifier (overrides auto-detection)
 - `VIPUNE_SIMILARITY_THRESHOLD` - Conflict detection threshold, 0.0-1.0 (default: `0.85`)
 - `VIPUNE_RECENCY_WEIGHT` - Recency bias in search results, 0.0-1.0 (default: `0.3`)
+- `VIPUNE_HYBRID` - Enable hybrid search (semantic + BM25), true/false or 1/0
 
 **Config file (`~/.config/vipune/config.toml`):**
 ```toml
@@ -284,8 +285,9 @@ Add to your Cursor MCP configuration with the same JSON structure.
 ### Available Tools
 
 - **store_memory**: Store information for later recall
-- **search_memories**: Find memories by meaning
+- **search_memories**: Find memories by meaning (supports `hybrid` param)
 - **list_memories**: List recent memories
+- **supersede_memory**: Replace an existing memory with new content
 
 ## Agent Integration
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -69,6 +69,12 @@ After completing work, store important findings:
 - `vipune list` shows recent memories
 - `vipune --help` displays all available commands
 
+**MCP tools** are also available (via `vipune mcp`):
+- `store_memory(text, metadata?, memory_type?, status?, supersedes?)` — store with optional type/status/supersede
+- `search_memories(query, limit?, memory_types?, statuses?, recency_weight?, hybrid?)` — find by meaning
+- `list_memories(limit?, memory_types?, statuses?)` — list recent
+- `supersede_memory(new_text, old_memory_id, memory_type?, metadata?)` — replace existing memory
+
 Keep entries focused: one atomic fact per memory for better retrieval.
 
 This memory persists across sessions and is scoped to your git project.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -106,6 +106,7 @@ vipune search <query> [--limit <n>] [--recency <weight>] [--hybrid] [--memory-ty
 - `-l, --limit <n>` - Maximum results to return (default: `5`)
 - `--recency <weight>` - Recency bias for scoring, 0.0 to 1.0 (default: from config, typically `0.3`)
 - `--hybrid` - Enables hybrid search combining semantic similarity with FTS5 full-text search using Reciprocal Rank Fusion (RRF)
+- `--no-hybrid` - Disables hybrid search even when enabled in config (useful to force pure semantic search)
 - `--memory-type <types>` - Filter by memory type (comma-separated, e.g., `guard,procedure`)
 - `--status <statuses>` - Filter by status (comma-separated, e.g., `active,candidate`)
 - `--include-candidates` - Shorthand to include both `active` and `candidate` memories
@@ -407,6 +408,7 @@ vipune mcp
 | `store_memory` | Store information for later recall |
 | `search_memories` | Find memories by meaning, with type/status filters |
 | `list_memories` | List recent memories, with type/status filters |
+| `supersede_memory` | Replace an existing memory with new content |
 
 **Exit codes:**
 - `0` - Success
@@ -417,12 +419,23 @@ vipune mcp
 `store_memory` accepts:
 - `text` — the information to remember (required)
 - `metadata` — optional structured labels as JSON (e.g., `{"topic": "auth"}`)
+- `memory_type` — type of memory: `fact` (default), `preference`, `procedure`, `guard`, `observation`
+- `status` — initial status: `active` (default) or `candidate`
+- `supersedes` — ID of memory to supersede (atomically replaces old memory)
 
-Note: Memory type, status, and supersede are available via CLI but not yet exposed in the MCP `store_memory` tool.
+`supersede_memory` accepts:
+- `new_text` — the new content that replaces the old memory (required)
+- `old_memory_id` — ID of the memory to supersede (required)
+- `memory_type` — optional type for the new memory (default: `fact`)
+- `metadata` — optional structured labels as JSON
 
 `search_memories` and `list_memories` accept optional:
 - `memory_types` — array of types to filter by (e.g., `["guard", "procedure"]`)
-- `status` — array of statuses to filter by (e.g., `["active", "candidate"]`)
+- `statuses` — array of statuses to filter by (e.g., `["active", "candidate"]`)
+
+`search_memories` also accepts:
+- `recency_weight` — recency bias for scoring, 0.0 to 1.0 (default: config value)
+- `hybrid` — use hybrid search (semantic + BM25), true/false (default: config value)
 
 **Example MCP configuration (Claude Code):**
 ```json


### PR DESCRIPTION
## Summary

Fixes 5 documentation drift items from v0.3.1 (PR #105):

- Removed stale claim that MCP store_memory lacks type/status/supersedes params
- Documented supersede_memory MCP tool in cli-reference.md and agent-integration.md
- Added --no-hybrid CLI flag to search command docs
- Added VIPUNE_HYBRID env var to README
- Documented store_memory v0.3 params (memory_type, status, supersedes)
- Documented search_memories hybrid and recency_weight MCP params

Fixes #112