### PR TITLE
chore(#107): use MemoryType/MemoryStatus enums at API boundaries

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -275,10 +275,8 @@ fn handle_add(
     supersedes: Option<&str>,
     json: bool,
 ) -> Result<ExitCode, Error> {
-    // Validate memory_type
-    let _ = MemoryType::from_str(memory_type)?;
-
-    // Validate status
+    // Parse memory_type and status
+    let memory_type_val = MemoryType::from_str(memory_type)?;
     let status_val = MemoryStatus::from_str(status)?;
     if !status_val.is_valid_for_insert() {
         return Err(Error::InvalidInput(format!(
@@ -296,7 +294,7 @@ fn handle_add(
 
     // If supersedes is provided, use supersede flow
     if let Some(old_id) = supersedes {
-        let new_id = store.supersede(project_id, text, metadata, memory_type, old_id)?;
+        let new_id = store.supersede(project_id, text, metadata, memory_type_val, old_id)?;
 
         if json {
             print_json(&AddResponse {
@@ -315,7 +313,14 @@ fn handle_add(
         IngestPolicy::ConflictAware
     };
 
-    match store.ingest_with_type_status(project_id, text, metadata, policy, memory_type, status)? {
+    match store.ingest_with_type_status(
+        project_id,
+        text,
+        metadata,
+        policy,
+        memory_type_val,
+        status_val,
+    )? {
         AddResult::Added { id } => {
             if json {
                 print_json(&AddResponse {
@@ -575,7 +580,11 @@ fn handle_update(
             .map_err(|e| Error::InvalidInput(format!("invalid metadata JSON: {}", e)))?;
     }
 
-    store.update(id, text, metadata, memory_type, status)?;
+    // Parse memory_type and status to enums
+    let memory_type_val = memory_type.map(MemoryType::from_str).transpose()?;
+    let status_val = status.map(MemoryStatus::from_str).transpose()?;
+
+    store.update(id, text, metadata, memory_type_val, status_val)?;
     if json {
         print_json(&UpdateResponse {
             status: "updated".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use vipune::{Config, MemoryStore, detect_project};
+//! use vipune::{Config, MemoryStore, MemoryType, MemoryStatus, detect_project};
 //!
 //! // Initialize memory store
 //! let config = Config::default();
@@ -20,7 +20,7 @@
 //! let project_id = detect_project(None);
 //!
 //! // Add a memory with conflict detection
-//! let result = store.add_with_conflict(&project_id, "Alice works at Microsoft", None, false, "fact", "active");
+//! let result = store.add_with_conflict(&project_id, "Alice works at Microsoft", None, false, MemoryType::Fact, MemoryStatus::Active);
 //! match result {
 //!     Ok(vipune::AddResult::Added { id }) => println!("Added memory: {}", id),
 //!     Ok(vipune::AddResult::Conflicts { .. }) => println!("Conflict detected"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -78,8 +78,8 @@ impl StoreWrapper {
         text: &str,
         metadata: &str,
         force: bool,
-        memory_type: &str,
-        status: &str,
+        memory_type: MemoryType,
+        status: MemoryStatus,
     ) -> Result<serde_json::Value, rmcp::ErrorData> {
         let mut store = self.0.lock().unwrap();
         let policy = if force {
@@ -130,17 +130,10 @@ impl StoreWrapper {
         project_id: &str,
         new_text: &str,
         metadata: &str,
-        memory_type: &str,
+        memory_type: MemoryType,
         old_memory_id: &str,
     ) -> Result<serde_json::Value, rmcp::ErrorData> {
         let mut store = self.0.lock().unwrap();
-
-        // Use mock embedding if embedder is not loaded (test mode)
-        let embedding = if store.embedder.is_none() {
-            crate::memory::crud::mock_embedding_for_content(new_text)
-        } else {
-            store.embedder()?.embed(new_text)?
-        };
 
         let metadata_str = if metadata == "null" {
             None
@@ -148,17 +141,15 @@ impl StoreWrapper {
             Some(metadata)
         };
 
-        let new_id = match store.db.supersede(
+        let new_id = match store.supersede(
             project_id,
             new_text,
-            &embedding,
             metadata_str,
             memory_type,
             old_memory_id,
         ) {
             Ok(id) => id,
             Err(err) => {
-                let err: Error = err.into();
                 return Err(err.into());
             }
         };
@@ -430,7 +421,7 @@ impl ToolHandler {
 
         // Parse and validate memory_type (default: "fact")
         let memory_type = params.memory_type.as_deref().unwrap_or("fact");
-        let _ = MemoryType::from_str(memory_type)
+        let memory_type_val = MemoryType::from_str(memory_type)
             .map_err(|e| McpError::invalid_input(&format!("Invalid memory type: {}", e)))?;
 
         // Parse and validate status (default: "active")
@@ -457,7 +448,7 @@ impl ToolHandler {
                 &self.project_id,
                 &params.text,
                 &metadata_str,
-                memory_type,
+                memory_type_val,
                 supersedes_id,
             )?;
             return Ok(CallToolResult::success(vec![Content::text(
@@ -471,8 +462,8 @@ impl ToolHandler {
             &params.text,
             &metadata_str,
             false,
-            memory_type,
-            status_str,
+            memory_type_val,
+            status_val,
         )?;
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -652,7 +643,7 @@ impl ToolHandler {
 
         // Parse and validate memory_type (default: "fact")
         let memory_type = params.memory_type.as_deref().unwrap_or("fact");
-        let _ = MemoryType::from_str(memory_type)
+        let memory_type_val = MemoryType::from_str(memory_type)
             .map_err(|e| McpError::invalid_input(&format!("Invalid memory type: {}", e)))?;
 
         // Serialize metadata
@@ -666,7 +657,7 @@ impl ToolHandler {
             &self.project_id,
             &params.new_text,
             &metadata_str,
-            memory_type,
+            memory_type_val,
             &params.old_memory_id,
         )?;
 

--- a/src/memory/crud.rs
+++ b/src/memory/crud.rs
@@ -1,6 +1,7 @@
 //! CRUD operations for the memory store.
 
 use crate::errors::Error;
+use crate::memory::lifecycle::{MemoryStatus, MemoryType};
 use crate::memory_types::{
     AddResult, BatchIngestItemResult, BatchIngestResult, ConflictMemory, IngestPolicy,
 };
@@ -69,12 +70,14 @@ impl MemoryStore {
         content: &str,
         metadata: Option<&str>,
         force: bool,
-        memory_type: &str,
-        status: &str,
+        memory_type: MemoryType,
+        status: MemoryStatus,
     ) -> Result<AddResult, Error> {
         Self::validate_input_length(content)?;
 
         let embedding = self.get_embedding(content)?;
+        let memory_type_str = memory_type.as_str();
+        let status_str = status.as_str();
 
         if force {
             let id = self.db.insert(
@@ -82,8 +85,8 @@ impl MemoryStore {
                 content,
                 &embedding,
                 metadata,
-                memory_type,
-                status,
+                memory_type_str,
+                status_str,
             )?;
             return Ok(AddResult::Added { id });
         }
@@ -106,8 +109,8 @@ impl MemoryStore {
                 content,
                 &embedding,
                 metadata,
-                memory_type,
-                status,
+                memory_type_str,
+                status_str,
             )?;
             Ok(AddResult::Added { id })
         } else {
@@ -167,7 +170,14 @@ impl MemoryStore {
         metadata: Option<&str>,
         policy: IngestPolicy,
     ) -> Result<AddResult, Error> {
-        self.ingest_with_type_status(project_id, content, metadata, policy, "fact", "active")
+        self.ingest_with_type_status(
+            project_id,
+            content,
+            metadata,
+            policy,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
     }
 
     /// Ingest with explicit memory type and status.
@@ -178,8 +188,8 @@ impl MemoryStore {
         content: &str,
         metadata: Option<&str>,
         policy: IngestPolicy,
-        memory_type: &str,
-        status: &str,
+        memory_type: MemoryType,
+        status: MemoryStatus,
     ) -> Result<AddResult, Error> {
         match policy {
             IngestPolicy::ConflictAware => {
@@ -257,8 +267,8 @@ impl MemoryStore {
         id: &str,
         content: Option<&str>,
         metadata: Option<&str>,
-        memory_type: Option<&str>,
-        status: Option<&str>,
+        memory_type: Option<MemoryType>,
+        status: Option<MemoryStatus>,
     ) -> Result<(), Error> {
         if content.is_none() && metadata.is_none() && memory_type.is_none() && status.is_none() {
             return Err(Error::InvalidInput(
@@ -277,19 +287,13 @@ impl MemoryStore {
                 .map_err(|e| Error::InvalidInput(format!("invalid metadata JSON: {}", e)))?;
         }
 
-        // Validate memory_type if provided
-        if let Some(t) = memory_type {
-            crate::memory::lifecycle::MemoryType::from_str(t)?;
-        }
-
         // Validate status if provided - reject "superseded"
         if let Some(s) = status {
-            if s.to_lowercase() == "superseded" {
+            if s == MemoryStatus::Superseded {
                 return Err(Error::InvalidInput(
                     "Cannot set status to 'superseded'. Use --supersedes flag instead.".to_string(),
                 ));
             }
-            crate::memory::lifecycle::MemoryStatus::from_str(s)?;
         }
 
         // If content is provided, validate and generate new embedding
@@ -305,8 +309,8 @@ impl MemoryStore {
             content,
             embedding.as_deref(),
             metadata,
-            memory_type,
-            status,
+            memory_type.map(|t| t.as_str()),
+            status.map(|s| s.as_str()),
         )?)
     }
 
@@ -469,9 +473,14 @@ impl MemoryStore {
                 Err(e) => BatchIngestItemResult::Error {
                     message: format!("{}", e),
                 },
-                Ok(()) => match self
-                    .add_with_conflict(project_id, content, metadata, force, "fact", "active")
-                {
+                Ok(()) => match self.add_with_conflict(
+                    project_id,
+                    content,
+                    metadata,
+                    force,
+                    MemoryType::Fact,
+                    MemoryStatus::Active,
+                ) {
                     Ok(AddResult::Added { id }) => BatchIngestItemResult::Added { id },
                     Ok(AddResult::Conflicts {
                         proposed,
@@ -512,7 +521,7 @@ impl MemoryStore {
         project_id: &str,
         content: &str,
         metadata: Option<&str>,
-        memory_type: &str,
+        memory_type: MemoryType,
         old_id: &str,
     ) -> Result<String, Error> {
         Self::validate_input_length(content)?;
@@ -526,9 +535,6 @@ impl MemoryStore {
                 .map_err(|e| Error::InvalidInput(format!("invalid metadata JSON: {}", e)))?;
         }
 
-        // Validate memory_type
-        crate::memory::lifecycle::MemoryType::from_str(memory_type)?;
-
         let embedding = self.get_embedding(content)?;
 
         Ok(self.db.supersede(
@@ -536,7 +542,7 @@ impl MemoryStore {
             content,
             &embedding,
             metadata,
-            memory_type,
+            memory_type.as_str(),
             old_id,
         )?)
     }

--- a/src/memory/tests/search.rs
+++ b/src/memory/tests/search.rs
@@ -1,6 +1,7 @@
 //! Tests for search operations.
 
 use crate::memory::MemoryStore;
+use crate::memory::lifecycle::{MemoryStatus, MemoryType};
 use crate::sqlite::Database;
 
 #[test]
@@ -312,8 +313,8 @@ fn test_integration_add_search_roundtrip() {
             "semantic search is useful",
             None,
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .unwrap()
     {
@@ -355,8 +356,8 @@ fn test_integration_update_changes_embedding() {
             "original content",
             None,
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .unwrap()
     {

--- a/tests/lib_integration.rs
+++ b/tests/lib_integration.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 
 use vipune::errors::Error;
 use vipune::{
-    Config, IngestPolicy, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT, MemoryStore, detect_project,
+    Config, IngestPolicy, MAX_INPUT_LENGTH, MAX_SEARCH_LIMIT, MemoryStatus, MemoryStore,
+    MemoryType, detect_project,
 };
 
 /// Test basic memory add and search operations.
@@ -27,8 +28,8 @@ fn test_memory_store_add_then_search_returns_matching_memory() {
             "Alice works at Microsoft",
             None,
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory")
     {
@@ -80,7 +81,14 @@ fn test_add_with_empty_input_returns_error() {
     let mut store = MemoryStore::new(db_path.as_path(), &config.embedding_model, config.clone())
         .expect("Failed to create store");
 
-    let result = store.add_with_conflict("test", "", None, false, "fact", "active");
+    let result = store.add_with_conflict(
+        "test",
+        "",
+        None,
+        false,
+        MemoryType::Fact,
+        MemoryStatus::Active,
+    );
     assert!(result.is_err());
     if !matches!(result.as_ref().unwrap_err(), Error::EmptyInput) {
         panic!("Expected EmptyInput error");
@@ -101,7 +109,14 @@ fn test_add_with_oversized_input_returns_error() {
 
     // Create input longer than MAX_INPUT_LENGTH
     let long_text = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.add_with_conflict("test", &long_text, None, false, "fact", "active");
+    let result = store.add_with_conflict(
+        "test",
+        &long_text,
+        None,
+        false,
+        MemoryType::Fact,
+        MemoryStatus::Active,
+    );
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -225,8 +240,8 @@ fn test_memory_with_stored_content_returns_expected_fields() {
             "Test content",
             Some(r#"{"key": "value"}"#),
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory")
     {
@@ -271,8 +286,8 @@ fn test_search_hybrid_with_test_memories_returns_fused_results() {
             "Authentication uses JWT tokens",
             None,
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory 1")
     {
@@ -285,8 +300,8 @@ fn test_search_hybrid_with_test_memories_returns_fused_results() {
             "User management system",
             None,
             false,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory 2")
     {
@@ -322,7 +337,14 @@ fn test_update_with_empty_input_returns_error() {
         .expect("Failed to create store");
 
     let memory_id = match store
-        .add_with_conflict("test", "Original content", None, false, "fact", "active")
+        .add_with_conflict(
+            "test",
+            "Original content",
+            None,
+            false,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -350,7 +372,14 @@ fn test_update_with_oversized_input_returns_error() {
         .expect("Failed to create store");
 
     let memory_id = match store
-        .add_with_conflict("test", "Original content", None, false, "fact", "active")
+        .add_with_conflict(
+            "test",
+            "Original content",
+            None,
+            false,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -442,7 +471,14 @@ fn test_add_with_whitespace_only_input_returns_error() {
         .expect("Failed to create store");
 
     // Try to add whitespace-only content
-    let result = store.add_with_conflict("test", "   ", None, false, "fact", "active");
+    let result = store.add_with_conflict(
+        "test",
+        "   ",
+        None,
+        false,
+        MemoryType::Fact,
+        MemoryStatus::Active,
+    );
     assert!(result.is_err());
     assert!(matches!(result.as_ref().unwrap_err(), Error::EmptyInput));
 
@@ -587,13 +623,34 @@ fn test_list_regression_coverage() {
 
     // Add multiple memories
     let _id1 = store
-        .add_with_conflict(project_id, "first memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "first memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
     let _id2 = store
-        .add_with_conflict(project_id, "second memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "second memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
     let _id3 = store
-        .add_with_conflict(project_id, "third memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "third memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
 
     // Test ordering (newest first)
@@ -619,8 +676,8 @@ fn test_list_regression_coverage() {
             "other memory",
             None,
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory");
     let project1_results = store
@@ -651,14 +708,28 @@ fn test_list_since_with_timezone_offset() {
 
     // Add memories with controlled timestamps
     let _old = store
-        .add_with_conflict(project_id, "old memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "old memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
 
     // Wait at least 1ms to ensure different timestamps
     std::thread::sleep(std::time::Duration::from_millis(10));
 
     let _new = store
-        .add_with_conflict(project_id, "new memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "new memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
 
     // Test with UTC timestamp (should succeed and only return newer)
@@ -687,7 +758,14 @@ fn test_list_since_timestamp_precision_equivalence() {
     let project_id = "test-project";
 
     let _id = store
-        .add_with_conflict(project_id, "test memory", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "test memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory");
 
     // Wait to ensure timestamp difference
@@ -727,7 +805,14 @@ fn test_get_many_with_duplicate_ids() {
     let project_id = "test-project";
 
     let id1 = match store
-        .add_with_conflict(project_id, "first", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "first",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -735,7 +820,14 @@ fn test_get_many_with_duplicate_ids() {
     };
 
     let id2 = match store
-        .add_with_conflict(project_id, "second", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "second",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add memory")
     {
         vipune::AddResult::Added { id } => id,
@@ -767,7 +859,14 @@ fn test_add_at_exactly_max_input_length_returns_success() {
 
     // Create input exactly at MAX_INPUT_LENGTH
     let exact_text = "x".repeat(MAX_INPUT_LENGTH);
-    let result = store.add_with_conflict("test", &exact_text, None, false, "fact", "active");
+    let result = store.add_with_conflict(
+        "test",
+        &exact_text,
+        None,
+        false,
+        MemoryType::Fact,
+        MemoryStatus::Active,
+    );
     assert!(
         result.is_ok(),
         "Should accept input at exactly MAX_INPUT_LENGTH"
@@ -788,7 +887,14 @@ fn test_add_one_over_max_input_length_returns_error() {
 
     // Create input one character over MAX_INPUT_LENGTH
     let too_long_text = "x".repeat(MAX_INPUT_LENGTH + 1);
-    let result = store.add_with_conflict("test", &too_long_text, None, false, "fact", "active");
+    let result = store.add_with_conflict(
+        "test",
+        &too_long_text,
+        None,
+        false,
+        MemoryType::Fact,
+        MemoryStatus::Active,
+    );
     assert!(result.is_err());
     if let Error::InputTooLong {
         max_length,
@@ -1097,8 +1203,8 @@ fn test_update_text_only_preserves_metadata() {
             "original content",
             Some(r#"{"tag": "important"}"#),
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add")
     {
@@ -1133,7 +1239,14 @@ fn test_update_with_invalid_json_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "original content",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1172,7 +1285,14 @@ fn test_update_with_empty_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "original content",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1211,7 +1331,14 @@ fn test_update_with_whitespace_only_metadata_returns_error() {
 
     // Add memory
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "original content",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1250,7 +1377,14 @@ fn test_update_metadata_only() {
 
     // Add memory without metadata
     let id = match store
-        .add_with_conflict(project_id, "original content", None, true, "fact", "active")
+        .add_with_conflict(
+            project_id,
+            "original content",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add")
     {
         vipune::AddResult::Added { id } => id,
@@ -1289,8 +1423,8 @@ fn test_update_both_text_and_metadata() {
             "old content",
             Some(r#"{"old": "value"}"#),
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add")
     {
@@ -1340,8 +1474,8 @@ fn test_add_with_conflict_creates_multiple_active_memories() {
             "memory A content",
             None,
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory A")
     {
@@ -1356,8 +1490,8 @@ fn test_add_with_conflict_creates_multiple_active_memories() {
             "memory B content",
             None,
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add memory B")
     {
@@ -1395,7 +1529,14 @@ fn test_default_search_excludes_candidate() {
 
     // Add active memory using add_with_conflict with force=true
     let _active_id = match store
-        .add_with_conflict(&project_id, "active memory", None, true, "fact", "active")
+        .add_with_conflict(
+            &project_id,
+            "active memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add active")
     {
         vipune::AddResult::Added { id } => id,
@@ -1409,8 +1550,8 @@ fn test_default_search_excludes_candidate() {
             "candidate memory",
             None,
             true,
-            "fact",
-            "candidate",
+            MemoryType::Fact,
+            MemoryStatus::Candidate,
         )
         .expect("Failed to add candidate")
     {
@@ -1450,7 +1591,14 @@ fn test_include_candidates_returns_both() {
 
     // Add active memory
     let _active_id = match store
-        .add_with_conflict(&project_id, "active memory", None, true, "fact", "active")
+        .add_with_conflict(
+            &project_id,
+            "active memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add active")
     {
         vipune::AddResult::Added { id } => id,
@@ -1464,8 +1612,8 @@ fn test_include_candidates_returns_both() {
             "candidate memory",
             None,
             true,
-            "fact",
-            "candidate",
+            MemoryType::Fact,
+            MemoryStatus::Candidate,
         )
         .expect("Failed to add candidate")
     {
@@ -1508,7 +1656,14 @@ fn test_default_list_excludes_non_active() {
 
     // Add memories with various statuses using add_with_conflict with force=true
     let _active_id = match store
-        .add_with_conflict(&project_id, "active memory", None, true, "fact", "active")
+        .add_with_conflict(
+            &project_id,
+            "active memory",
+            None,
+            true,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        )
         .expect("Failed to add active")
     {
         vipune::AddResult::Added { id } => id,
@@ -1521,8 +1676,8 @@ fn test_default_list_excludes_non_active() {
             "candidate memory",
             None,
             true,
-            "fact",
-            "candidate",
+            MemoryType::Fact,
+            MemoryStatus::Candidate,
         )
         .expect("Failed to add candidate")
     {
@@ -1536,8 +1691,8 @@ fn test_default_list_excludes_non_active() {
             "deprecated memory",
             None,
             true,
-            "fact",
-            "deprecated",
+            MemoryType::Fact,
+            MemoryStatus::Deprecated,
         )
         .expect("Failed to add deprecated")
     {
@@ -1576,8 +1731,8 @@ fn test_hybrid_search_respects_status_filter() {
             "rust programming language",
             None,
             true,
-            "fact",
-            "active",
+            MemoryType::Fact,
+            MemoryStatus::Active,
         )
         .expect("Failed to add active")
     {
@@ -1592,8 +1747,8 @@ fn test_hybrid_search_respects_status_filter() {
             "old rust programming info",
             None,
             true,
-            "fact",
-            "candidate",
+            MemoryType::Fact,
+            MemoryStatus::Candidate,
         )
         .expect("Failed to add candidate")
     {
@@ -1644,8 +1799,8 @@ fn test_supersede_through_public_api() {
         "original memory content",
         None,
         true,
-        "fact",
-        "active",
+        MemoryType::Fact,
+        MemoryStatus::Active,
     ) {
         Ok(vipune::AddResult::Added { id }) => id,
         Ok(other) => panic!("Expected Added, got {:?}", other),
@@ -1666,7 +1821,7 @@ fn test_supersede_through_public_api() {
             &project_id,
             "updated memory content",
             Some(r#"{"updated": true}"#),
-            "fact",
+            MemoryType::Fact,
             &original_id,
         )
         .expect("Failed to supersede");


### PR DESCRIPTION
## Summary

Replaces `&str` parameters with `MemoryType`/`MemoryStatus` enums at the MemoryStore API boundary, providing compile-time type safety.

### Changes
- **MemoryStore methods** (`add_with_conflict`, `ingest_with_type_status`, `update`, `supersede`) now accept enum types
- **CLI boundary** (`commands.rs`) parses strings to enums via `from_str()`
- **MCP boundary** (`tools.rs`) same pattern
- **Database layer** unchanged — still uses `&str` (MemoryStore calls `.as_str()`)
- **Tests** updated to use enum values

### Impact
No runtime behavior change. Invalid type/status values now caught at compile time instead of runtime `from_str` validation inside MemoryStore.

Fixes #107