### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-01
+
+### Miscellaneous
+
+- *(deps)* Bump actions/upload-artifact from 6 to 7 ([#29](https://github.com/randomm/vipune/pull/29))
+- *(deps)* Bump toml from 0.8.23 to 1.0.6+spec-1.1.0 ([#51](https://github.com/randomm/vipune/pull/51))
+- *(deps)* Bump actions/download-artifact from 7 to 8 ([#28](https://github.com/randomm/vipune/pull/28))
+
+
 ## [0.4.0] - 2026-04-28
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,7 +2189,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vipune"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vipune"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vipune`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `vipune` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Memory.retrieval_count in /tmp/.tmpKdxpcb/vipune/src/sqlite/mod.rs:60
  field Memory.last_retrieved_at in /tmp/.tmpKdxpcb/vipune/src/sqlite/mod.rs:62

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vipune::memory::MemoryStore::search now takes 5 parameters instead of 6, in /tmp/.tmpKdxpcb/vipune/src/memory/search.rs:51
  vipune::memory::MemoryStore::search_hybrid now takes 5 parameters instead of 6, in /tmp/.tmpKdxpcb/vipune/src/memory/search.rs:133
  vipune::MemoryStore::search now takes 5 parameters instead of 6, in /tmp/.tmpKdxpcb/vipune/src/memory/search.rs:51
  vipune::MemoryStore::search_hybrid now takes 5 parameters instead of 6, in /tmp/.tmpKdxpcb/vipune/src/memory/search.rs:133

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct vipune::mcp::tools::McpError, previously in file /tmp/.tmpHjmNGf/vipune/src/mcp/tools.rs:331
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0] - 2026-05-01

### Miscellaneous

- *(deps)* Bump actions/upload-artifact from 6 to 7 ([#29](https://github.com/randomm/vipune/pull/29))
- *(deps)* Bump toml from 0.8.23 to 1.0.6+spec-1.1.0 ([#51](https://github.com/randomm/vipune/pull/51))
- *(deps)* Bump actions/download-artifact from 7 to 8 ([#28](https://github.com/randomm/vipune/pull/28))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).