### PR TITLE
chore(#122): upgrade cargo-dist to v0.31.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.4/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v7
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ strip = true
 # Config for 'dist'
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.4"
+cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ strip = true
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
+allow-dirty = ["ci"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
Upgrades cargo-dist from v0.30.4 to v0.31.0 to resolve release workflow failures.

The release workflow was failing because cargo-dist v0.30.4 expected upload-artifact@v6 and download-artifact@v7, but dependabot PRs #28/#29 bumped them to v7/v8. Upgrading cargo-dist resolves the version mismatch.

### Changes
- Updated cargo-dist-version in Cargo.toml to 0.31.0
- Updated dist installer URL in release.yml

Fixes #122