### PR TITLE
fix(#130): enable changelog updates via release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,10 @@
 [workspace]
 # Generate changelog from conventional commits
 changelog_config = "cliff.toml"
+# Enable changelog updates via release-pr job
+changelog_update = true
+# Path to changelog file
+changelog_path = "./CHANGELOG.md"
 # Publish to crates.io with trusted publishing
 publish = true
 # Create git tags automatically (triggers cargo-dist)


### PR DESCRIPTION
Adds `changelog_update = true` and `changelog_path = "./CHANGELOG.md"` to `release-plz.toml` so that release-plz automatically populates CHANGELOG.md when creating release PRs via the `release-pr` job.

Fixes #130