### PR TITLE
chore(#129): fix stale version refs, backfill CHANGELOG, add MCP debugging guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,84 +6,188 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5.0] - 2026-05-01
 
-### Miscellaneous
+### Added
 
-- *(deps)* Bump actions/upload-artifact from 6 to 7 ([#29](https://github.com/randomm/vipune/pull/29))
-- *(deps)* Bump toml from 0.8.23 to 1.0.6+spec-1.1.0 ([#51](https://github.com/randomm/vipune/pull/51))
-- *(deps)* Bump actions/download-artifact from 7 to 8 ([#28](https://github.com/randomm/vipune/pull/28))
+- Add retrieval_count and last_retrieved_at telemetry (#118)
+- Add public MemoryStore::supersede method (#113)
+
+### Fixed
+
+- Update embedding model revision to main branch (#117)
+
+### Changed
+
+- Refactor oversized files to meet 500-line limit (#120)
+- Use MemoryType/MemoryStatus enums at API boundaries (#119)
+
+### Documentation
+
+- Fix documentation drift from v0.3.0 changes (#114)
+
+### Dependencies
+
+- Bump actions/upload-artifact from 6 to 7
+- Bump actions/download-artifact from 7 to 8
+- Bump toml from 0.8.23 to 1.0.6+spec-1.1.0
+- Upgrade cargo-dist to v0.31.0 (#123)
 
 
 ## [0.4.0] - 2026-04-28
 
+### Fixed
+
+- Fix lifecycle bugs, search consistency, and hybrid config (#105)
+
 
 ## [0.3.0] - 2026-04-27
+
+### Added
+
+- Add memory type, lifecycle status, and atomic supersede (#97)
+- Extend update command to support metadata changes (#95)
+- Include metadata and project_id in MCP search results (#93)
+
+### Fixed
+
+- Fail-fast on over-length content instead of silent truncation (#92)
+
+### Changed
+
+- Add schema migration framework for SQLite (#91)
+
+### Documentation
+
+- Update documentation for v0.3 API changes (#98)
 
 
 ## [0.2.6] - 2026-04-18
 
+### Added
+
+- Pin embedding model revision and expose public constants (#84)
+
 
 ## [0.2.5] - 2026-04-12
+
+### Fixed
+
+- Keep MCP server alive until client disconnects (#80)
 
 
 ## [0.2.4] - 2026-04-11
 
+### Changed
+
+- Make MCP a default feature (#76)
+
 
 ## [0.2.3] - 2026-04-10
+
+### Added
+
+- Add vipune mcp subcommand with MCP server (#74)
 
 
 ## [0.2.2] - 2026-04-09
 
+### Added
+
+- Add shell installer and fix macOS tar extraction bug (#70)
+
 
 ## [0.2.1] - 2026-03-27
 
+### Added
+
+- Add batch ingest API with per-item outcomes (#68)
+- Add ergonomic ingest API to MemoryStore (#65)
+- Add list_since and get_many read helpers (#66)
+
+### Documentation
+
+- Audit and evolve project documentation (#59)
 
 ## [0.2.0] - 2026-03-24
+
+### Added
+
+- Expose Memory.embedding field and add MemoryStore::list() (#54)
+
+### Changed
+
+- Downgrade ort from 2.0.0-rc.11 to 2.0.0-rc.9 (#56)
 
 
 ## [0.1.9] - 2026-03-09
 
+### Fixed
+
+- Add download-binaries feature to ort dependency (#46)
+
 
 ## [0.1.8] - 2026-03-02
+
+### Changed
+
+- Upgrade to Rust edition 2024 with MSRV 1.85 (#40)
 
 
 ## [0.1.7] - 2026-03-02
 
-### Bug Fixes
+### Fixed
 
 - MacOS install instructions and code block copy-paste UX
 
 
 ## [0.1.6] - 2026-03-01
 
-### Bug Fixes
+### Fixed
 
 - Correct install instructions to use .tar.xz instead of .tar.gz
 
 
 ## [0.1.5] - 2026-02-28
 
-### Bug Fixes
+### Fixed
 
 - Lazy embedding init to prevent flaky tests on HF 404
 - Keep all tests active, cache HF models in CI instead of #[ignore]
 
+### Documentation
+
+- Replace hardcoded version tag with cargo install from crates.io
+
 
 ## [0.1.4] - 2026-02-27
+
+### Fixed
+
+- Upgrade ort from rc.10 to rc.11 and fix inputs() API (#18)
+- Pin macOS runner to macos-14 for ort rc.11 Xcode 15.4 compatibility (#25)
+- Switch CI to Ubicloud Ubuntu 24.04 runners (#22)
 
 
 ## [0.1.3] - 2026-02-26
 
+### Fixed
+
+- Upgrade rusqlite from 0.32 to 0.38 (#17)
+
 
 ## [0.1.2] - 2026-02-21
 
-### Features
+### Added
 
-- Initial release of vipune v0.1.1
+- Add lib.rs public API, security hardening, and integration tests (#11)
+
+### Fixed
+
+- Add release-pr job to release-plz workflow (#14)
 
 
 ## [0.1.1] - 2026-02-19
 
-### Features
+### Added
 
 - Semantic memory storage with vector embeddings (BAAI/bge-small-en-v1.5)
 - SQLite backend with schema, CRUD, and cosine similarity search

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ vipune can also be used as a Rust crate for programmatic integration:
 ```toml
 # Cargo.toml
 [dependencies]
-vipune = "0.3.0"
+vipune = "0.5.0"
 ```
 
 ```rust
@@ -226,7 +226,7 @@ for memory in results {
 }
 ```
 
-**v0.3 features**: `MemoryType`, `MemoryStatus`, `supersedes` flag, and filter parameters are available for type-aware memory management. See the [CLI reference](docs/cli-reference.md) for details.
+**v0.4+ features**: `MemoryType`, `MemoryStatus`, `supersedes` flag, and telemetry (retrieval_count) are available for type-aware memory management. See the [CLI reference](docs/cli-reference.md) for details.
 
 **See the crate documentation at [docs.rs](https://docs.rs/vipune) for complete API reference.**
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ vipune = "0.5.0"
 ```
 
 ```rust
-use vipune::{Config, MemoryStore, detect_project};
+use vipune::{Config, MemoryStore, MemoryType, MemoryStatus, detect_project};
 
 // Initialize memory store
 let config = Config::default();
@@ -214,11 +214,11 @@ let mut store = MemoryStore::new(
 
 // Add a memory
 let project_id = "my-project";
-let memory_id = store.add(&project_id, "Alice works at Microsoft", None)
+let result = store.add_with_conflict(&project_id, "Alice works at Microsoft", None, false, vipune::MemoryType::Fact, vipune::MemoryStatus::Active)
     .expect("Failed to add memory");
 
 // Search memories
-let results = store.search(&project_id, "where does alice work", 10, 0.0, None, None)
+let results = store.search(&project_id, "where does alice work", 10, 0.0, vipune::memory::SearchOptions::default())
     .expect("Failed to search");
 
 for memory in results {

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -14,7 +14,7 @@ Use vipune to create a feedback cycle in your agent workflow:
 2. **Do the work** - Execute your task with the knowledge in mind
 3. **Store learnings** - `vipune add "important discovery"` after completing meaningful work
 
-### v0.3 memory types
+### Memory types
 
 Memories can be categorized by type for routing and filtering:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ vipune is a single Rust binary CLI tool for semantic memory storage and search. 
 
 - **Library core is sync-only**: No async runtime in `src/lib.rs` (no tokio). All operations block until complete. This eliminates complexity and runtime overhead.
 - **MCP server uses tokio**: The MCP server module uses an async runtime (tokio) when enabled (default feature).
-- **No daemon**: CLI tool only — runs, executes, and exits. No long-lived server process.
+- **No daemon** — with one exception: `vipune mcp` runs as a persistent JSON-RPC server until stdin closes. All other commands run, execute, and exit.
 - **No network at runtime**: All dependencies are bundled. HuggingFace Hub model downloads happen once and are cached locally.
 - **SQLite for persistence**: Data stored in `~/.vipune/memories.db` using rusqlite (bundled, no external SQLite installation required).
 - **ONNX for embeddings**: bge-small-en-v1.5 model (384 dimensions) for semantic search, with local inference via ONNX Runtime.
@@ -162,7 +162,7 @@ Configurable parameters include:
 
 **Lib and bin targets**: `src/lib.rs` (public API exports) and `src/main.rs` (CLI entry point). Single release artifact enables both library use and CLI tool.
 
-**No daemon**: Tool exits after operation. State lives only in SQLite; no in-memory caches survive between invocations.
+**No daemon** — with one exception: `vipune mcp` runs as a persistent JSON-RPC server until stdin closes. All other commands exit after operation. State lives only in SQLite; no in-memory caches survive between invocations.
 
 **File size limits**: Source files capped at 500 lines (exceptions justified). Keeps modules focused, testable, and maintainable.
 

--- a/docs/mcp-debugging.md
+++ b/docs/mcp-debugging.md
@@ -2,6 +2,8 @@
 
 This guide helps developers debug the vipune MCP server integration with AI agents like Claude Code and Cursor.
 
+Note: unlike all other vipune commands, `vipune mcp` is long-lived by design — it's the single architectural exception to vipune's no-daemon policy.
+
 ## Running the MCP Server Locally
 
 ### Standalone Mode
@@ -39,14 +41,7 @@ Create a test script (`test-mcp.sh`) to send requests via stdin:
 ```bash
 #!/bin/bash
 # Send a JSON-RPC request to MCP server
-
-PAYLOAD='{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/list"
-}'
-
-echo "$PAYLOAD" | vipune mcp
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | vipune mcp
 ```
 
 ### Example Tool Calls
@@ -65,7 +60,7 @@ Each MCP tool has a specific JSON-RPC format:
     "arguments": {
       "text": "Alice works at Microsoft",
       "memory_type": "fact",
-      "metadata": "{\"topic\": \"people\"}"
+      "metadata": {"topic": "people"}
     }
   }
 }
@@ -129,10 +124,15 @@ Each MCP tool has a specific JSON-RPC format:
 Use `rlwrap` for an interactive stdin session:
 
 ```bash
-pip install rlwrap
+# macOS
+brew install rlwrap
+# Ubuntu/Debian
+sudo apt install rlwrap
+```
 
-# Start server with readline support
-vipune mcp | rlwrap
+```bash
+# Note: responses will interleave with the readline prompt
+rlwrap vipune mcp
 ```
 
 Then paste JSON-RPC payloads directly (press Ctrl+D after each to send).
@@ -147,14 +147,12 @@ Then paste JSON-RPC payloads directly (press Ctrl+D after each to send).
 
 **Solution**: Ensure JSON-RPC messages end with newline (`\n`). The MCP protocol expects line-delimited JSON.
 
-**Bad** (no newline):
-```json
-{"jsonrpc":"2.0","id":1,"method":"tools/list"}
-```
+```bash
+# Bad: no trailing newline (server may not process the request)
+printf '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | vipune mcp
 
-**Good** (with newline):
-```json
-{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+# Good: explicit newline using echo (echo always adds \n)
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | vipune mcp
 ```
 
 ### Line Ending Issues
@@ -187,7 +185,7 @@ echo '{"jsonrpc":"2.0","id":1}' | dos2unix | vipune mcp
 
 **Debug with jq**:
 ```bash
-echo 'your-json-here' | jq .  # Validate JSON before sending
+echo 'your-json-here' | jq -c .  # Validate JSON before sending (compact/single-line output)
 ```
 
 ### Tool Registration Issues
@@ -318,7 +316,7 @@ After verifying basic JSON-RPC, test with actual agent:
 If issues persist:
 
 1. Check server logs with `RUST_LOG=debug`
-2. Verify JSON-RPC payloads are valid (`jq .`)
+2. Verify JSON-RPC payloads are valid (`jq -c .`)
 3. Test with minimal examples above
 4. Check project isolation (use `--project` to bypass git detection)
 5. Review agent's MCP client logs

--- a/docs/mcp-debugging.md
+++ b/docs/mcp-debugging.md
@@ -1,0 +1,331 @@
+# MCP Debugging Guide
+
+This guide helps developers debug the vipune MCP server integration with AI agents like Claude Code and Cursor.
+
+## Running the MCP Server Locally
+
+### Standalone Mode
+
+The MCP server runs via stdio and expects JSON-RPC messages. Start it directly:
+
+```bash
+# Start MCP server (auto-detected project)
+vipune mcp
+
+# With explicit project ID
+vipune mcp --project my-project
+```
+
+### Via Cargo (Development)
+
+When developing locally:
+
+```bash
+# Build and run MCP server
+cargo run -- mcp
+
+# With explicit project
+cargo run -- mcp --project my-project
+```
+
+The server will block and wait for JSON-RPC messages on stdin. It runs until the client disconnects or stdin closes.
+
+## Testing JSON-RPC Requests
+
+### Basic Test Script
+
+Create a test script (`test-mcp.sh`) to send requests via stdin:
+
+```bash
+#!/bin/bash
+# Send a JSON-RPC request to MCP server
+
+PAYLOAD='{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list"
+}'
+
+echo "$PAYLOAD" | vipune mcp
+```
+
+### Example Tool Calls
+
+Each MCP tool has a specific JSON-RPC format:
+
+#### store_memory
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "store_memory",
+    "arguments": {
+      "text": "Alice works at Microsoft",
+      "memory_type": "fact",
+      "metadata": "{\"topic\": \"people\"}"
+    }
+  }
+}
+```
+
+#### search_memories
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "search_memories",
+    "arguments": {
+      "query": "where does alice work",
+      "memory_types": ["fact"],
+      "limit": 5
+    }
+  }
+}
+```
+
+#### list_memories
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "list_memories",
+    "arguments": {
+      "limit": 10,
+      "memory_types": ["fact"]
+    }
+  }
+}
+```
+
+#### supersede_memory
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": {
+    "name": "supersede_memory",
+    "arguments": {
+      "old_memory_id": "uuid-here",
+      "new_text": "Alice works at Google as a senior engineer",
+      "memory_type": "fact"
+    }
+  }
+}
+```
+
+### Interactive Testing
+
+Use `rlwrap` for an interactive stdin session:
+
+```bash
+pip install rlwrap
+
+# Start server with readline support
+vipune mcp | rlwrap
+```
+
+Then paste JSON-RPC payloads directly (press Ctrl+D after each to send).
+
+## Common Issues
+
+### Buffering Problems
+
+**Symptom**: Responses don't appear immediately.
+
+**Cause**: stdio buffering delays output.
+
+**Solution**: Ensure JSON-RPC messages end with newline (`\n`). The MCP protocol expects line-delimited JSON.
+
+**Bad** (no newline):
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+**Good** (with newline):
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+### Line Ending Issues
+
+**Symptom**: Server hangs or parse errors.
+
+**Cause**: Windows CRLF (`\r\n`) vs Unix LF (`\n`) line endings.
+
+**Solution**: Use POSIX-compliant tools:
+
+```bash
+# macOS/Linux - correct line endings
+echo '{"jsonrpc":"2.0","id":1}' | vipune mcp
+
+# Windows/convert - sanitize line endings
+echo '{"jsonrpc":"2.0","id":1}' | dos2unix | vipune mcp
+```
+
+### JSON Format Errors
+
+**Symptom**: `Parse error: invalid JSON`.
+
+**Cause**: Malformed JSON-RPC payload.
+
+**Common mistakes:**
+- Missing `jsonrpc: "2.0"` field
+- Missing `id` field (required for requests)
+- Unclosed braces or quotes
+- Invalid escape sequences in `text` field
+
+**Debug with jq**:
+```bash
+echo 'your-json-here' | jq .  # Validate JSON before sending
+```
+
+### Tool Registration Issues
+
+**Symptom**: Agent reports "tool not found" or blank tool list.
+
+**Cause**: MCP handler not exposing tools correctly.
+
+**Verification steps:**
+
+1. Check `tools/list` returns tools:
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+Expected response includes `store_memory`, `search_memories`, `list_memories`, `supersede_memory`.
+
+2. Verify tool names match agent expectations (case-sensitive):
+- `store_memory` ✅
+- `Store_Memory` ❌
+- `storeMemory` ❌
+
+3. Check server logs (see Debug Logging below)
+
+### Project Detection Failures
+
+**Symptom**: Missing project_id in results, or wrong project.
+
+**Cause**: Not in a git repository, or git detection fails.
+
+**Debug:**
+
+```bash
+# Force explicit project
+vipune mcp --project my-project
+
+# Check git detection
+git rev-parse --git-dir  # Should return .git path
+```
+
+## Debug Logging
+
+### Environment Variables
+
+vipune uses Rust's `env_logger`. Enable logging before starting MCP:
+
+```bash
+# Enable all debug output
+RUST_LOG=debug vipune mcp
+
+# MCP-specific debugging
+RUST_LOG=vipune::mcp=debug vipune mcp
+
+# Store wrapper debugging
+RUST_LOG=vipune::mcp::store_wrapper=trace vipune mcp
+```
+
+### Log Levels
+
+- `trace` - Extremely verbose, every step
+- `debug` - Detailed information flow
+- `info` - High-level operations (default)
+- `warn` - Warning messages
+- `error` - Error conditions only
+
+### Example Session with Logging
+
+```bash
+RUST_LOG=debug vipune mcp <<EOF
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+EOF
+```
+
+Output shows:
+- Tools registered
+- Request received
+- Response generated
+- Errors (if any)
+
+## Verification Checklist
+
+### Server Starts Successfully
+
+- [ ] `vipune mcp` doesn't crash immediately
+- [ ] Process blocks waiting for input (expected)
+- [ ] No panics or assertion failures
+
+### tools/list Works
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | vipune mcp
+```
+
+- [ ] Returns JSON response
+- [ ] `result.tools` array has 4 tools
+- [ ] Tool names: `store_memory`, `search_memories`, `list_memories`, `supersede_memory`
+
+### Store Memory Works
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"store_memory","arguments":{"text":"test memory"}}}
+```
+
+- [ ] Returns success response
+- [ ] `toolCallId` or result contains memory ID
+- [ ] No errors in response
+
+### Search Memory Works
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_memories","arguments":{"query":"test"}}}
+```
+
+- [ ] Returns array of memories
+- [ ] Each memory has `content`, `id`, `similarity` (or `score`)
+
+### Agent Integration Tests
+
+After verifying basic JSON-RPC, test with actual agent:
+
+- [ ] Claude Code: Add to `~/.claude/settings.json`, check MCP tools appear
+- [ ] Cursor: Add to MCP config, test `store_memory` call
+- [ ] Verify project auto-detection works (project_id appears in results)
+- [ ] Check search results include metadata when provided
+
+## Getting Help
+
+If issues persist:
+
+1. Check server logs with `RUST_LOG=debug`
+2. Verify JSON-RPC payloads are valid (`jq .`)
+3. Test with minimal examples above
+4. Check project isolation (use `--project` to bypass git detection)
+5. Review agent's MCP client logs
+
+For bug reports, include:
+- VIPune version: `vipune version`
+- OS and platform
+- JSON-RPC request payload (sanitized)
+- Full error message
+- `RUST_LOG=debug` output


### PR DESCRIPTION
- Fixes `vipune = "0.3.0"` → `"0.5.0"` in README.md Cargo example
- Removes stale "v0.3 features" line from README
- Backfills all empty CHANGELOG.md version sections (v0.1.1–v0.5.0) from git history using Keep a Changelog format
- Adds `docs/mcp-debugging.md` — developer guide for testing the MCP server locally

Fixes #129