### PR TITLE
feat(#128): add get_memory, delete_memory, update_memory MCP tools

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -409,6 +409,9 @@ vipune mcp
 | `search_memories` | Find memories by meaning, with type/status filters |
 | `list_memories` | List recent memories, with type/status filters |
 | `supersede_memory` | Replace an existing memory with new content |
+| `get_memory` | Retrieve a specific memory by ID |
+| `delete_memory` | Delete a memory permanently by ID |
+| `update_memory` | Update an existing memory's content, metadata, type, or status |
 
 **Exit codes:**
 - `0` - Success
@@ -422,6 +425,7 @@ vipune mcp
 - `memory_type` — type of memory: `fact` (default), `preference`, `procedure`, `guard`, `observation`
 - `status` — initial status: `active` (default) or `candidate`
 - `supersedes` — ID of memory to supersede (atomically replaces old memory)
+- `force` — force store even if conflicts detected (default: `false`)
 
 `supersede_memory` accepts:
 - `new_text` — the new content that replaces the old memory (required)
@@ -429,9 +433,25 @@ vipune mcp
 - `memory_type` — optional type for the new memory (default: `fact`)
 - `metadata` — optional structured labels as JSON
 
+`get_memory` accepts:
+- `id` — ID of the memory to retrieve (required)
+- `no_touch` — skip updating retrieval telemetry (default: `false`)
+
+`delete_memory` accepts:
+- `id` — ID of the memory to delete (required)
+
+`update_memory` accepts:
+- `id` — ID of the memory to update (required)
+- `text` — optional new content for the memory
+- `metadata` — optional new metadata as JSON object
+- `memory_type` — optional new memory type
+- `status` — optional new status: `active` or `candidate`
+  (At least one optional field must be provided)
+
 `search_memories` and `list_memories` accept optional:
 - `memory_types` — array of types to filter by (e.g., `["guard", "procedure"]`)
 - `statuses` — array of statuses to filter by (e.g., `["active", "candidate"]`)
+- `no_touch` — skip updating retrieval telemetry (default: `false`)
 
 `search_memories` also accepts:
 - `recency_weight` — recency bias for scoring, 0.0 to 1.0 (default: config value)

--- a/src/commands/handlers.rs
+++ b/src/commands/handlers.rs
@@ -236,11 +236,12 @@ pub(crate) fn handle_search(
 pub(crate) fn handle_get(
     store: &mut MemoryStore,
     id: &str,
+    project_id: &str,
     no_touch: bool,
     json: bool,
 ) -> Result<ExitCode, Error> {
     let memory = store
-        .get(id)?
+        .get(id, project_id)?
         .ok_or_else(|| Error::NotFound("memory not found".to_string()))?;
 
     if !no_touch {
@@ -319,9 +320,10 @@ pub(crate) fn handle_list(
 pub(crate) fn handle_delete(
     store: &mut MemoryStore,
     id: &str,
+    project_id: &str,
     json: bool,
 ) -> Result<ExitCode, Error> {
-    let deleted = store.delete(id)?;
+    let deleted = store.delete(id, project_id)?;
     if deleted {
         if json {
             print_json(&DeleteResponse {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -187,7 +187,9 @@ pub fn execute(
             config,
             json,
         ),
-        Commands::Get { id, no_touch } => handlers::handle_get(store, id, *no_touch, json),
+        Commands::Get { id, no_touch } => {
+            handlers::handle_get(store, id, &project_id, *no_touch, json)
+        }
         Commands::List {
             limit,
             memory_type,
@@ -202,7 +204,7 @@ pub fn execute(
             *include_candidates,
             json,
         ),
-        Commands::Delete { id } => handlers::handle_delete(store, id, json),
+        Commands::Delete { id } => handlers::handle_delete(store, id, &project_id, json),
         Commands::Update {
             id,
             text,

--- a/src/mcp/helpers.rs
+++ b/src/mcp/helpers.rs
@@ -1,0 +1,34 @@
+//! Helper functions for MCP tool implementations.
+
+use crate::sqlite::Memory;
+
+/// Formats a memory (with similarity score) as JSON for MCP responses.
+pub fn format_memory_json(memory: &Memory) -> serde_json::Value {
+    let metadata_value = parse_metadata(&memory.metadata);
+    let similarity = memory.similarity.unwrap_or(0.0);
+
+    serde_json::json!({
+        "id": memory.id,
+        "content": memory.content,
+        "similarity": similarity,
+        "created_at": memory.created_at,
+        "updated_at": memory.updated_at,
+        "project_id": memory.project_id,
+        "memory_type": memory.memory_type,
+        "status": memory.status,
+        "metadata": metadata_value,
+        "retrieval_count": memory.retrieval_count,
+        "last_retrieved_at": memory.last_retrieved_at
+    })
+}
+
+/// Parses metadata string into JSON value.
+fn parse_metadata(metadata: &Option<String>) -> serde_json::Value {
+    match metadata {
+        Some(meta_str) if meta_str.trim() != "null" => {
+            serde_json::from_str::<serde_json::Value>(meta_str)
+                .unwrap_or_else(|_| serde_json::Value::String(meta_str.clone()))
+        }
+        _ => serde_json::Value::Null,
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -21,6 +21,7 @@
 //! run_mcp(config.embedding_model, "default", config.database_path).expect("Failed to start MCP server");
 //! ```
 
+mod helpers;
 mod params;
 pub mod server;
 pub mod store_wrapper;

--- a/src/mcp/params.rs
+++ b/src/mcp/params.rs
@@ -36,6 +36,11 @@ pub struct StoreMemoryParams {
         description = "ID of memory to supersede (creates new memory, marks old as superseded)."
     )]
     pub supersedes: Option<String>,
+
+    /// Force store even if conflicts detected (default: false).
+    #[serde(default)]
+    #[schemars(description = "Force store even if conflicts detected (default: false).")]
+    pub force: Option<bool>,
 }
 
 /// Parameters for the supersede_memory tool.
@@ -126,6 +131,50 @@ pub struct SuccessResponse {
     pub id: String,
     /// Status
     pub status: String,
+}
+
+/// Parameters for the get_memory tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct GetMemoryParams {
+    /// ID of the memory to retrieve.
+    #[schemars(description = "ID of the memory to retrieve.")]
+    pub id: String,
+    /// Skip updating retrieval telemetry (default: false).
+    #[serde(default)]
+    #[schemars(description = "Skip updating retrieval telemetry (default: false).")]
+    pub no_touch: Option<bool>,
+}
+
+/// Parameters for the delete_memory tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct DeleteMemoryParams {
+    /// ID of the memory to delete.
+    #[schemars(description = "ID of the memory to delete.")]
+    pub id: String,
+}
+
+/// Parameters for the update_memory tool.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct UpdateMemoryParams {
+    /// ID of the memory to update.
+    #[schemars(description = "ID of the memory to update.")]
+    pub id: String,
+    /// New text content for the memory.
+    #[serde(default)]
+    #[schemars(description = "New text content for the memory.")]
+    pub text: Option<String>,
+    /// New metadata as JSON object.
+    #[serde(default)]
+    #[schemars(description = "New metadata as JSON object.")]
+    pub metadata: Option<serde_json::Value>,
+    /// New memory type: fact, preference, procedure, guard, observation.
+    #[serde(default)]
+    #[schemars(description = "New memory type: fact, preference, procedure, guard, observation.")]
+    pub memory_type: Option<String>,
+    /// New memory status: active, candidate.
+    #[serde(default)]
+    #[schemars(description = "New memory status: active, candidate.")]
+    pub status: Option<String>,
 }
 
 /// A conflicting memory.

--- a/src/mcp/store_wrapper.rs
+++ b/src/mcp/store_wrapper.rs
@@ -155,6 +155,32 @@ impl StoreWrapper {
         .map_err(McpError::from_serde_error)
     }
 
+    /// Search memories by semantic meaning, returning raw Memory structs.
+    pub(crate) fn search_raw(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+        recency_weight: f64,
+        options: crate::memory::SearchOptions,
+    ) -> Result<Vec<crate::Memory>, Error> {
+        let mut store = self.0.lock().unwrap();
+        store.search(project_id, query, limit, recency_weight, options)
+    }
+
+    /// Search memories by hybrid (semantic + BM25), returning raw Memory structs.
+    pub(crate) fn search_hybrid_raw(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+        recency_weight: f64,
+        options: crate::memory::SearchOptions,
+    ) -> Result<Vec<crate::Memory>, Error> {
+        let mut store = self.0.lock().unwrap();
+        store.search_hybrid(project_id, query, limit, recency_weight, options)
+    }
+
     /// Search memories by semantic meaning.
     #[allow(dead_code)] // Used in tests but not in actual MCP flow
     pub(crate) fn search(
@@ -288,6 +314,47 @@ impl StoreWrapper {
     #[allow(dead_code)]
     pub(crate) fn inner(&self) -> &Arc<Mutex<MemoryStore>> {
         &self.0
+    }
+
+    /// Get a specific memory by ID.
+    #[allow(dead_code)] // Used by get_memory tool
+    pub(crate) fn get(&self, id: &str) -> Result<Option<crate::Memory>, rmcp::ErrorData> {
+        let store = self.0.lock().unwrap();
+        store.get(id).map_err(|e| -> rmcp::ErrorData { e.into() })
+    }
+
+    /// Delete a memory by ID.
+    #[allow(dead_code)] // Used by delete_memory tool
+    pub(crate) fn delete(&self, id: &str) -> Result<bool, rmcp::ErrorData> {
+        let store = self.0.lock().unwrap();
+        store
+            .delete(id)
+            .map_err(|e| -> rmcp::ErrorData { e.into() })
+    }
+
+    /// Update a memory's content, metadata, type, or status.
+    #[allow(dead_code)] // Used by update_memory tool
+    pub(crate) fn update(
+        &self,
+        id: &str,
+        text: Option<&str>,
+        metadata: Option<&str>,
+        memory_type: Option<MemoryType>,
+        status: Option<MemoryStatus>,
+    ) -> Result<(), rmcp::ErrorData> {
+        let mut store = self.0.lock().unwrap();
+        store
+            .update(id, text, metadata, memory_type, status)
+            .map_err(|e| -> rmcp::ErrorData { e.into() })
+    }
+
+    /// Update retrieval telemetry for a list of memory IDs.
+    #[allow(dead_code)] // Used by search_memories and get_memory tools
+    pub(crate) fn touch_memories(&self, ids: &[&str]) -> Result<(), rmcp::ErrorData> {
+        let store = self.0.lock().unwrap();
+        store
+            .touch_memories(ids)
+            .map_err(|e| -> rmcp::ErrorData { e.into() })
     }
 }
 

--- a/src/mcp/store_wrapper.rs
+++ b/src/mcp/store_wrapper.rs
@@ -316,19 +316,37 @@ impl StoreWrapper {
         &self.0
     }
 
-    /// Get a specific memory by ID.
+    /// Get a specific memory by ID scoped to a project.
     #[allow(dead_code)] // Used by get_memory tool
-    pub(crate) fn get(&self, id: &str) -> Result<Option<crate::Memory>, rmcp::ErrorData> {
-        let store = self.0.lock().unwrap();
-        store.get(id).map_err(|e| -> rmcp::ErrorData { e.into() })
+    pub(crate) fn get(
+        &self,
+        id: &str,
+        project_id: &str,
+    ) -> Result<Option<crate::Memory>, rmcp::ErrorData> {
+        let store = self.0.lock().map_err(|e| {
+            rmcp::ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("store lock poisoned: {e}"),
+                None,
+            )
+        })?;
+        store
+            .get(id, project_id)
+            .map_err(|e| -> rmcp::ErrorData { e.into() })
     }
 
-    /// Delete a memory by ID.
+    /// Delete a memory by ID scoped to a project.
     #[allow(dead_code)] // Used by delete_memory tool
-    pub(crate) fn delete(&self, id: &str) -> Result<bool, rmcp::ErrorData> {
-        let store = self.0.lock().unwrap();
+    pub(crate) fn delete(&self, id: &str, project_id: &str) -> Result<bool, rmcp::ErrorData> {
+        let store = self.0.lock().map_err(|e| {
+            rmcp::ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("store lock poisoned: {e}"),
+                None,
+            )
+        })?;
         store
-            .delete(id)
+            .delete(id, project_id)
             .map_err(|e| -> rmcp::ErrorData { e.into() })
     }
 
@@ -342,7 +360,13 @@ impl StoreWrapper {
         memory_type: Option<MemoryType>,
         status: Option<MemoryStatus>,
     ) -> Result<(), rmcp::ErrorData> {
-        let mut store = self.0.lock().unwrap();
+        let mut store = self.0.lock().map_err(|e| {
+            rmcp::ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("store lock poisoned: {e}"),
+                None,
+            )
+        })?;
         store
             .update(id, text, metadata, memory_type, status)
             .map_err(|e| -> rmcp::ErrorData { e.into() })
@@ -351,7 +375,13 @@ impl StoreWrapper {
     /// Update retrieval telemetry for a list of memory IDs.
     #[allow(dead_code)] // Used by search_memories and get_memory tools
     pub(crate) fn touch_memories(&self, ids: &[&str]) -> Result<(), rmcp::ErrorData> {
-        let store = self.0.lock().unwrap();
+        let store = self.0.lock().map_err(|e| {
+            rmcp::ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("store lock poisoned: {e}"),
+                None,
+            )
+        })?;
         store
             .touch_memories(ids)
             .map_err(|e| -> rmcp::ErrorData { e.into() })

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -339,7 +339,7 @@ mod tool_handler_tests {
         let id = response["id"].as_str().unwrap();
 
         // Get the memory by ID
-        let memory_result = wrapper.get(id);
+        let memory_result = wrapper.get(id, project_id);
         assert!(memory_result.is_ok());
         let memory_opt = memory_result.unwrap();
         assert!(memory_opt.is_some());
@@ -351,7 +351,7 @@ mod tool_handler_tests {
         assert_eq!(memory.project_id, project_id);
 
         // Try to get a non-existent memory, verify it returns None
-        let nonexistent_result = wrapper.get("nonexistent-id");
+        let nonexistent_result = wrapper.get("nonexistent-id", project_id);
         assert!(nonexistent_result.is_ok());
         assert!(nonexistent_result.unwrap().is_none());
     }
@@ -373,12 +373,12 @@ mod tool_handler_tests {
         let id = response["id"].as_str().unwrap();
 
         // Delete the memory
-        let delete_result = wrapper.delete(id);
+        let delete_result = wrapper.delete(id, project_id);
         assert!(delete_result.is_ok());
         assert!(delete_result.unwrap(), "delete should return true");
 
         // Try to get the deleted memory, verify it's not found
-        let get_result = wrapper.get(id);
+        let get_result = wrapper.get(id, project_id);
         assert!(get_result.is_ok());
         assert!(
             get_result.unwrap().is_none(),
@@ -386,7 +386,7 @@ mod tool_handler_tests {
         );
 
         // Try to delete again, verify it returns false
-        let delete_again_result = wrapper.delete(id);
+        let delete_again_result = wrapper.delete(id, project_id);
         assert!(delete_again_result.is_ok());
         assert!(
             !delete_again_result.unwrap(),
@@ -424,7 +424,7 @@ mod tool_handler_tests {
         assert!(update_result.is_ok(), "update should succeed");
 
         // Verify the content changed by getting the memory
-        let get_result = wrapper.get(id);
+        let get_result = wrapper.get(id, project_id);
         assert!(get_result.is_ok());
         let memory_opt = get_result.unwrap();
         assert!(memory_opt.is_some());
@@ -438,7 +438,7 @@ mod tool_handler_tests {
         assert!(update_meta_result.is_ok());
 
         // Verify metadata updated
-        let get_meta_result = wrapper.get(id);
+        let get_meta_result = wrapper.get(id, project_id);
         assert!(get_meta_result.is_ok());
         let memory_meta_opt = get_meta_result.unwrap();
         assert!(memory_meta_opt.is_some());
@@ -466,7 +466,7 @@ mod tool_handler_tests {
         assert!(update_type_status_result.is_ok());
 
         // Verify type and status updated
-        let get_final_result = wrapper.get(id);
+        let get_final_result = wrapper.get(id, project_id);
         assert!(get_final_result.is_ok());
         let memory_final_opt = get_final_result.unwrap();
         assert!(memory_final_opt.is_some());

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -42,6 +42,7 @@ mod tool_handler_tests {
             memory_type: None,
             status: None,
             supersedes: None,
+            force: None,
         };
 
         let json = serde_json::to_string(&params).unwrap();
@@ -51,6 +52,7 @@ mod tool_handler_tests {
         assert!(decoded.memory_type.is_none());
         assert!(decoded.status.is_none());
         assert!(decoded.supersedes.is_none());
+        assert!(decoded.force.is_none());
     }
 
     /// Test that StoreMemoryParams with all fields serializes correctly.
@@ -62,6 +64,7 @@ mod tool_handler_tests {
             memory_type: Some("preference".to_string()),
             status: Some("active".to_string()),
             supersedes: Some("old-memory-id".to_string()),
+            force: Some(true),
         };
 
         let json = serde_json::to_string(&params).unwrap();
@@ -71,6 +74,7 @@ mod tool_handler_tests {
         assert_eq!(decoded.memory_type, Some("preference".to_string()));
         assert_eq!(decoded.status, Some("active".to_string()));
         assert_eq!(decoded.supersedes, Some("old-memory-id".to_string()));
+        assert_eq!(decoded.force, Some(true));
     }
 
     /// Test that SupersedeMemoryParams serializes and deserializes correctly.
@@ -313,5 +317,161 @@ mod tool_handler_tests {
         let first_result = &results[0];
         assert!(first_result.get("metadata").is_some());
         assert_eq!(first_result["metadata"], serde_json::Value::Null);
+    }
+
+    /// Test get_memory integration: store a memory and retrieve it by ID.
+    #[tokio::test]
+    async fn test_get_memory_integration() {
+        let (store, _dir) = create_test_store();
+        let store = Arc::new(Mutex::new(store));
+        let wrapper = StoreWrapper::new(store.clone());
+        let project_id = "test-project";
+
+        // Store a memory via ingest
+        let result = wrapper.ingest(project_id, "test memory content", "null", false);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        let json_str = serde_json::to_string(&value).unwrap();
+        assert!(json_str.contains("added"));
+
+        // Extract the ID from the response
+        let response: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let id = response["id"].as_str().unwrap();
+
+        // Get the memory by ID
+        let memory_result = wrapper.get(id);
+        assert!(memory_result.is_ok());
+        let memory_opt = memory_result.unwrap();
+        assert!(memory_opt.is_some());
+        let memory = memory_opt.unwrap();
+
+        // Verify the returned memory has the expected content
+        assert_eq!(memory.id, id);
+        assert_eq!(memory.content, "test memory content");
+        assert_eq!(memory.project_id, project_id);
+
+        // Try to get a non-existent memory, verify it returns None
+        let nonexistent_result = wrapper.get("nonexistent-id");
+        assert!(nonexistent_result.is_ok());
+        assert!(nonexistent_result.unwrap().is_none());
+    }
+
+    /// Test delete_memory integration: store, delete, and verify deletion.
+    #[tokio::test]
+    async fn test_delete_memory_integration() {
+        let (store, _dir) = create_test_store();
+        let store = Arc::new(Mutex::new(store));
+        let wrapper = StoreWrapper::new(store.clone());
+        let project_id = "test-project";
+
+        // Store a memory
+        let result = wrapper.ingest(project_id, "memory to delete", "null", false);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        let json_str = serde_json::to_string(&value).unwrap();
+        let response: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let id = response["id"].as_str().unwrap();
+
+        // Delete the memory
+        let delete_result = wrapper.delete(id);
+        assert!(delete_result.is_ok());
+        assert!(delete_result.unwrap(), "delete should return true");
+
+        // Try to get the deleted memory, verify it's not found
+        let get_result = wrapper.get(id);
+        assert!(get_result.is_ok());
+        assert!(
+            get_result.unwrap().is_none(),
+            "deleted memory should not be found"
+        );
+
+        // Try to delete again, verify it returns false
+        let delete_again_result = wrapper.delete(id);
+        assert!(delete_again_result.is_ok());
+        assert!(
+            !delete_again_result.unwrap(),
+            "deleting non-existent memory should return false"
+        );
+    }
+
+    /// Test update_memory integration: store, update, and verify update.
+    #[tokio::test]
+    async fn test_update_memory_integration() {
+        use crate::memory::lifecycle::{MemoryStatus, MemoryType};
+
+        let (store, _dir) = create_test_store();
+        let store = Arc::new(Mutex::new(store));
+        let wrapper = StoreWrapper::new(store.clone());
+        let project_id = "test-project";
+
+        // Store a memory
+        let result = wrapper.ingest_with_type_status(
+            project_id,
+            "original content",
+            "null",
+            false,
+            MemoryType::Fact,
+            MemoryStatus::Active,
+        );
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        let json_str = serde_json::to_string(&value).unwrap();
+        let response: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        let id = response["id"].as_str().unwrap();
+
+        // Update the memory with new text
+        let update_result = wrapper.update(id, Some("updated content"), None, None, None);
+        assert!(update_result.is_ok(), "update should succeed");
+
+        // Verify the content changed by getting the memory
+        let get_result = wrapper.get(id);
+        assert!(get_result.is_ok());
+        let memory_opt = get_result.unwrap();
+        assert!(memory_opt.is_some());
+        let memory = memory_opt.unwrap();
+        assert_eq!(memory.content, "updated content");
+
+        // Update with new metadata
+        let new_metadata = serde_json::json!({"topic": "test", "updated": true});
+        let metadata_str = serde_json::to_string(&new_metadata).unwrap();
+        let update_meta_result = wrapper.update(id, None, Some(&metadata_str), None, None);
+        assert!(update_meta_result.is_ok());
+
+        // Verify metadata updated
+        let get_meta_result = wrapper.get(id);
+        assert!(get_meta_result.is_ok());
+        let memory_meta_opt = get_meta_result.unwrap();
+        assert!(memory_meta_opt.is_some());
+        let memory_meta = memory_meta_opt.unwrap();
+        assert!(memory_meta.metadata.is_some());
+        let stored_metadata: serde_json::Value =
+            serde_json::from_str(memory_meta.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(stored_metadata, new_metadata);
+
+        // Try to update with all None optional fields, should fail
+        let update_none_result = wrapper.update(id, None, None, None, None);
+        assert!(
+            update_none_result.is_err(),
+            "update with all None fields should fail"
+        );
+
+        // Update with new type and status
+        let update_type_status_result = wrapper.update(
+            id,
+            None,
+            None,
+            Some(MemoryType::Preference),
+            Some(MemoryStatus::Candidate),
+        );
+        assert!(update_type_status_result.is_ok());
+
+        // Verify type and status updated
+        let get_final_result = wrapper.get(id);
+        assert!(get_final_result.is_ok());
+        let memory_final_opt = get_final_result.unwrap();
+        assert!(memory_final_opt.is_some());
+        let memory_final = memory_final_opt.unwrap();
+        assert_eq!(memory_final.memory_type, MemoryType::Preference.as_str());
+        assert_eq!(memory_final.status, MemoryStatus::Candidate.as_str());
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,5 +1,6 @@
 //! MCP tool implementations.
 
+use crate::mcp::helpers::format_memory_json;
 use crate::mcp::store_wrapper::{McpError, StoreWrapper};
 
 use crate::errors::Error;
@@ -95,11 +96,12 @@ impl ToolHandler {
         }
 
         // Normal ingest path with type and status
+        let force = params.force.unwrap_or(false);
         let value = self.store.ingest_with_type_status(
             &self.project_id,
             &params.text,
             &metadata_str,
-            false,
+            force,
             memory_type_val,
             status_val,
         )?;
@@ -128,6 +130,7 @@ impl ToolHandler {
         }
 
         let limit = params.limit.unwrap_or(5);
+        let no_touch = params.no_touch.unwrap_or(false);
 
         // Validate limit
         if limit == 0 {
@@ -143,67 +146,49 @@ impl ToolHandler {
         let recency_weight = params.recency_weight.unwrap_or(self.config.recency_weight);
         let use_hybrid = params.hybrid.unwrap_or(self.config.hybrid);
 
-        let memories = {
-            let mut store = self.store.0.lock().unwrap();
-            let type_strs: Option<Vec<&str>> = params
-                .memory_types
-                .as_ref()
-                .map(|v| v.iter().map(|s| s.as_str()).collect());
-            let status_strs: Option<Vec<&str>> = params
-                .statuses
-                .as_ref()
-                .map(|v| v.iter().map(|s| s.as_str()).collect());
-            let search_options = crate::memory::SearchOptions {
-                memory_types: type_strs,
-                statuses: status_strs,
-            };
-            if use_hybrid {
-                store
-                    .search_hybrid(
-                        &self.project_id,
-                        &params.query,
-                        limit,
-                        recency_weight,
-                        search_options,
-                    )
-                    .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?
-            } else {
-                store
-                    .search(
-                        &self.project_id,
-                        &params.query,
-                        limit,
-                        recency_weight,
-                        search_options,
-                    )
-                    .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?
-            }
+        let type_strs: Option<Vec<&str>> = params
+            .memory_types
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let status_strs: Option<Vec<&str>> = params
+            .statuses
+            .as_ref()
+            .map(|v| v.iter().map(|s| s.as_str()).collect());
+        let search_options = crate::memory::SearchOptions {
+            memory_types: type_strs,
+            statuses: status_strs,
+        };
+        let memories = if use_hybrid {
+            self.store
+                .search_hybrid_raw(
+                    &self.project_id,
+                    &params.query,
+                    limit,
+                    recency_weight,
+                    search_options,
+                )
+                .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?
+        } else {
+            self.store
+                .search_raw(
+                    &self.project_id,
+                    &params.query,
+                    limit,
+                    recency_weight,
+                    search_options,
+                )
+                .map_err(|e: Error| -> rmcp::ErrorData { e.into() })?
         };
 
-        // Build JSON response manually (Memory doesn't derive Serialize)
-        let results: Vec<serde_json::Value> = memories
-            .into_iter()
-            .map(|m| {
-                let metadata_value = match m.metadata {
-                    Some(ref meta_str) if meta_str.trim() != "null" => {
-                        serde_json::from_str::<serde_json::Value>(meta_str)
-                            .unwrap_or_else(|_| serde_json::Value::String(meta_str.clone()))
-                    }
-                    _ => serde_json::Value::Null,
-                };
-                serde_json::json!({
-                    "id": m.id,
-                    "content": m.content,
-                    "similarity": m.similarity.unwrap_or(0.0),
-                    "created_at": m.created_at,
-                    "updated_at": m.updated_at,
-                    "project_id": m.project_id,
-                    "metadata": metadata_value,
-                    "retrieval_count": m.retrieval_count,
-                    "last_retrieved_at": m.last_retrieved_at
-                })
-            })
-            .collect();
+        // Update retrieval telemetry unless no_touch is true
+        if !no_touch && !memories.is_empty() {
+            let memory_ids: Vec<String> = memories.iter().map(|m| m.id.clone()).collect();
+            let id_refs: Vec<&str> = memory_ids.iter().map(|s| s.as_str()).collect();
+            let _ = self.store.touch_memories(&id_refs);
+        }
+
+        // Build JSON response using helper
+        let results: Vec<serde_json::Value> = memories.iter().map(format_memory_json).collect();
 
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string(&results).map_err(McpError::from_serde_error)?,
@@ -301,6 +286,161 @@ impl ToolHandler {
 
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string(&value).map_err(McpError::from_serde_error)?,
+        )]))
+    }
+
+    /// Retrieve a specific memory by ID.
+    ///
+    /// Use when you know the exact memory ID.
+    #[tool(
+        name = "get_memory",
+        description = "Retrieve a specific memory by ID. Use when you know the exact memory ID."
+    )]
+    async fn get_memory(
+        &self,
+        Parameters(params): Parameters<GetMemoryParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate input
+        if params.id.trim().is_empty() {
+            return Err(McpError::invalid_input("ID cannot be empty"));
+        }
+
+        // Get the memory
+        let memory_opt = self.store.get(&params.id)?;
+        let memory = match memory_opt {
+            Some(m) => m,
+            None => {
+                return Err(McpError::invalid_input(&format!(
+                    "memory not found: {}",
+                    params.id
+                )));
+            }
+        };
+
+        // Update retrieval telemetry unless no_touch is true
+        if !params.no_touch.unwrap_or(false) {
+            let _ = self.store.touch_memories(&[memory.id.as_str()]);
+        }
+
+        // Format memory as JSON using helper
+        let result = format_memory_json(&memory);
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&result).map_err(McpError::from_serde_error)?,
+        )]))
+    }
+
+    /// Delete a memory permanently by ID.
+    #[tool(
+        name = "delete_memory",
+        description = "Delete a memory permanently by ID."
+    )]
+    async fn delete_memory(
+        &self,
+        Parameters(params): Parameters<DeleteMemoryParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate input
+        if params.id.trim().is_empty() {
+            return Err(McpError::invalid_input("ID cannot be empty"));
+        }
+
+        let deleted = self.store.delete(&params.id)?;
+
+        if !deleted {
+            return Err(McpError::invalid_input(&format!(
+                "memory not found: {}",
+                params.id
+            )));
+        }
+
+        let result = serde_json::json!({
+            "id": params.id,
+            "status": "deleted"
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&result).map_err(McpError::from_serde_error)?,
+        )]))
+    }
+
+    /// Update an existing memory's content, metadata, type, or status.
+    ///
+    /// At least one field must be provided.
+    #[tool(
+        name = "update_memory",
+        description = "Update an existing memory's content, metadata, type, or status. At least one field must be provided."
+    )]
+    async fn update_memory(
+        &self,
+        Parameters(params): Parameters<UpdateMemoryParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // Validate input
+        if params.id.trim().is_empty() {
+            return Err(McpError::invalid_input("ID cannot be empty"));
+        }
+
+        // Validate at least one optional field is provided
+        if params.text.is_none()
+            && params.metadata.is_none()
+            && params.memory_type.is_none()
+            && params.status.is_none()
+        {
+            return Err(McpError::invalid_input(
+                "At least one of text, metadata, memory_type, or status must be provided",
+            ));
+        }
+
+        // Parse memory_type if provided
+        let memory_type_val = if let Some(ref mt) = params.memory_type {
+            let mt_str = mt.as_str();
+            Some(
+                MemoryType::from_str(mt_str)
+                    .map_err(|e| McpError::invalid_input(&format!("Invalid memory type: {}", e)))?,
+            )
+        } else {
+            None
+        };
+
+        // Parse status if provided
+        let status_val = if let Some(ref s) = params.status {
+            let s_str = s.as_str();
+            Some(
+                MemoryStatus::from_str(s_str)
+                    .map_err(|e| McpError::invalid_input(&format!("Invalid status: {}", e)))?,
+            )
+        } else {
+            None
+        };
+
+        // Serialize metadata if provided
+        let metadata_str = if let Some(ref meta) = params.metadata {
+            Some(
+                serde_json::to_string(meta)
+                    .map_err(|e| McpError::invalid_input(&format!("Invalid metadata: {}", e)))?,
+            )
+        } else {
+            None
+        };
+
+        // Convert text to &str if provided
+        let text_str = params.text.as_deref();
+
+        // Perform the update
+        self.store.update(
+            &params.id,
+            text_str,
+            metadata_str.as_deref(),
+            memory_type_val,
+            status_val,
+        )?;
+
+        let result = serde_json::json!({
+            "id": params.id,
+            "status": "updated"
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string(&result).map_err(McpError::from_serde_error)?,
         )]))
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -182,9 +182,10 @@ impl ToolHandler {
 
         // Update retrieval telemetry unless no_touch is true
         if !no_touch && !memories.is_empty() {
-            let memory_ids: Vec<String> = memories.iter().map(|m| m.id.clone()).collect();
-            let id_refs: Vec<&str> = memory_ids.iter().map(|s| s.as_str()).collect();
-            let _ = self.store.touch_memories(&id_refs);
+            let id_refs: Vec<&str> = memories.iter().map(|m| m.id.as_str()).collect();
+            if let Err(e) = self.store.touch_memories(&id_refs) {
+                eprintln!("warning: touch_memories failed (telemetry not updated): {e}");
+            }
         }
 
         // Build JSON response using helper
@@ -305,8 +306,8 @@ impl ToolHandler {
             return Err(McpError::invalid_input("ID cannot be empty"));
         }
 
-        // Get the memory
-        let memory_opt = self.store.get(&params.id)?;
+        // Get the memory (scoped to current project)
+        let memory_opt = self.store.get(&params.id, &self.project_id)?;
         let memory = match memory_opt {
             Some(m) => m,
             None => {
@@ -319,7 +320,9 @@ impl ToolHandler {
 
         // Update retrieval telemetry unless no_touch is true
         if !params.no_touch.unwrap_or(false) {
-            let _ = self.store.touch_memories(&[memory.id.as_str()]);
+            if let Err(e) = self.store.touch_memories(&[memory.id.as_str()]) {
+                eprintln!("warning: touch_memories failed (telemetry not updated): {e}");
+            }
         }
 
         // Format memory as JSON using helper
@@ -344,7 +347,7 @@ impl ToolHandler {
             return Err(McpError::invalid_input("ID cannot be empty"));
         }
 
-        let deleted = self.store.delete(&params.id)?;
+        let deleted = self.store.delete(&params.id, &self.project_id)?;
 
         if !deleted {
             return Err(McpError::invalid_input(&format!(

--- a/src/memory/batch_tests.rs
+++ b/src/memory/batch_tests.rs
@@ -82,7 +82,7 @@ fn test_batch_ingest_mixed_outcomes() {
         BatchIngestItemResult::Added { id } => {
             assert!(!id.is_empty());
             // Verify it was actually stored
-            let memory = store.get(id).unwrap().unwrap();
+            let memory = store.get(id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "Bob works at Google");
         }
         _ => panic!("Expected Added for item 1, got {:?}", result.results[1]),
@@ -106,7 +106,7 @@ fn test_batch_ingest_mixed_outcomes() {
         BatchIngestItemResult::Added { id } => {
             assert!(!id.is_empty());
             // Verify it was actually stored
-            let memory = store.get(id).unwrap().unwrap();
+            let memory = store.get(id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "Charlie works at Amazon");
         }
         _ => panic!("Expected Added for item 3, got {:?}", result.results[3]),
@@ -173,7 +173,7 @@ fn test_batch_ingest_deterministic_index_mapping() {
 
     // Verify index 3 is Added (unique with metadata)
     if let BatchIngestItemResult::Added { id } = &result.results[3] {
-        let memory = store.get(id).unwrap().unwrap();
+        let memory = store.get(id, "test-project").unwrap().unwrap();
         assert_eq!(memory.content, "unique item 3");
         assert_eq!(memory.metadata, Some("metadata".to_string()));
     } else {
@@ -224,7 +224,7 @@ fn test_batch_ingest_policy_force() {
         BatchIngestItemResult::Added { id } => {
             assert!(!id.is_empty());
             // Verify it was actually stored despite potential similarity
-            let memory = store.get(id).unwrap().unwrap();
+            let memory = store.get(id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "Alice works at Microsoft");
         }
         _ => panic!("Expected Added for item 0 with Force policy"),
@@ -233,7 +233,7 @@ fn test_batch_ingest_policy_force() {
     match &result.results[1] {
         BatchIngestItemResult::Added { id } => {
             assert!(!id.is_empty());
-            let memory = store.get(id).unwrap().unwrap();
+            let memory = store.get(id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "Bob works at Google");
         }
         _ => panic!("Expected Added for item 1 with Force policy"),
@@ -289,7 +289,7 @@ fn test_batch_ingest_invalid_inputs() {
     match &result.results[3] {
         BatchIngestItemResult::Added { id } => {
             assert!(!id.is_empty());
-            let memory = store.get(id).unwrap().unwrap();
+            let memory = store.get(id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "valid input");
         }
         _ => panic!("Expected Added for valid input at index 3"),
@@ -359,21 +359,21 @@ fn test_batch_ingest_metadata_preservation() {
 
     // Verify metadata is preserved for items 0 and 2
     if let BatchIngestItemResult::Added { id } = &result.results[0] {
-        let memory = store.get(id).unwrap().unwrap();
+        let memory = store.get(id, "test-project").unwrap().unwrap();
         assert_eq!(memory.metadata, Some(r#"{"tag": "important"}"#.to_string()));
     } else {
         panic!("Expected Added for item 0");
     }
 
     if let BatchIngestItemResult::Added { id } = &result.results[1] {
-        let memory = store.get(id).unwrap().unwrap();
+        let memory = store.get(id, "test-project").unwrap().unwrap();
         assert_eq!(memory.metadata, None);
     } else {
         panic!("Expected Added for item 1");
     }
 
     if let BatchIngestItemResult::Added { id } = &result.results[2] {
-        let memory = store.get(id).unwrap().unwrap();
+        let memory = store.get(id, "test-project").unwrap().unwrap();
         assert_eq!(
             memory.metadata,
             Some(r#"{"source": "user", "priority": 1}"#.to_string())

--- a/src/memory/crud.rs
+++ b/src/memory/crud.rs
@@ -200,11 +200,16 @@ impl MemoryStore {
     }
 
     #[must_use = "handle the error or results may be lost"]
-    /// Get a specific memory by ID.
+    /// Get a specific memory by ID scoped to a project.
     ///
-    /// Returns `None` if the memory doesn't exist.
-    pub fn get(&self, id: &str) -> Result<Option<Memory>, Error> {
-        Ok(self.db.get(id)?)
+    /// Returns `None` if the memory doesn't exist or belongs to a different project.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Memory ID to retrieve
+    /// * `project_id` - Project identifier (scope guard)
+    pub fn get(&self, id: &str, project_id: &str) -> Result<Option<Memory>, Error> {
+        Ok(self.db.get(id, project_id)?)
     }
 
     #[must_use = "handle the error or results may be lost"]
@@ -313,13 +318,18 @@ impl MemoryStore {
     }
 
     #[must_use = "handle the error or results may be lost"]
-    /// Delete a memory.
+    /// Delete a memory scoped to a project.
     ///
     /// Returns:
     /// - `Ok(true)` if memory was deleted
-    /// - `Ok(false)` if memory didn't exist
-    pub fn delete(&self, id: &str) -> Result<bool, Error> {
-        Ok(self.db.delete(id)?)
+    /// - `Ok(false)` if memory didn't exist or belongs to a different project
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Memory ID to delete
+    /// * `project_id` - Project identifier (scope guard)
+    pub fn delete(&self, id: &str, project_id: &str) -> Result<bool, Error> {
+        Ok(self.db.delete(id, project_id)?)
     }
 
     /// Increment retrieval_count and set last_retrieved_at for given memory IDs.

--- a/src/memory/tests/crud.rs
+++ b/src/memory/tests/crud.rs
@@ -32,7 +32,7 @@ fn test_add_and_get() {
         )
         .unwrap();
 
-    let memory = db.get(&id).unwrap().unwrap();
+    let memory = db.get(&id, "test-project").unwrap().unwrap();
     assert_eq!(memory.id, id);
     assert_eq!(memory.content, "test content");
     assert_eq!(memory.project_id, "test-project");
@@ -64,7 +64,7 @@ fn test_update_memory() {
     db.update(&id, Some("updated"), Some(&embedding_new), None, None, None)
         .unwrap();
 
-    let memory = db.get(&id).unwrap().unwrap();
+    let memory = db.get(&id, "test-project").unwrap().unwrap();
     assert_eq!(memory.content, "updated");
     assert_ne!(memory.created_at, memory.updated_at);
 }
@@ -110,9 +110,9 @@ fn test_delete_memory() {
             "active",
         )
         .unwrap();
-    assert!(db.delete(&id).unwrap());
+    assert!(db.delete(&id, "test-project").unwrap());
 
-    let memory = db.get(&id).unwrap();
+    let memory = db.get(&id, "test-project").unwrap();
     assert!(memory.is_none());
 }
 
@@ -124,7 +124,7 @@ fn test_delete_nonexistent() {
     std::mem::forget(dir);
 
     let db = Database::open(&path).unwrap();
-    let deleted = db.delete("does-not-exist").unwrap();
+    let deleted = db.delete("does-not-exist", "test-project").unwrap();
     assert!(!deleted);
 }
 
@@ -136,7 +136,7 @@ fn test_get_nonexistent() {
     std::mem::forget(dir);
 
     let db = Database::open(&path).unwrap();
-    let memory = db.get("does-not-exist").unwrap();
+    let memory = db.get("does-not-exist", "test-project").unwrap();
     assert!(memory.is_none());
 }
 

--- a/src/memory/tests/ingest.rs
+++ b/src/memory/tests/ingest.rs
@@ -46,7 +46,7 @@ fn test_ingest_happy_path_conflict_aware() {
         AddResult::Added { id } => {
             assert!(!id.is_empty());
             // Verify memory was actually stored
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, "new memory");
         }
         AddResult::Conflicts { .. } => panic!("Expected AddResult::Added"),
@@ -155,7 +155,7 @@ fn test_ingest_with_metadata() {
 
     match result {
         AddResult::Added { id } => {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(memory.metadata, Some(metadata.to_string()));
         }
         AddResult::Conflicts { .. } => panic!("Expected AddResult::Added"),

--- a/src/memory/tests/ingest_boundary.rs
+++ b/src/memory/tests/ingest_boundary.rs
@@ -141,7 +141,7 @@ fn test_ingest_metadata_with_special_json_characters_succeeds() {
 
         // Verify metadata was stored correctly
         if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(memory.metadata, Some(metadata.to_string()));
         }
     }
@@ -181,7 +181,7 @@ fn test_ingest_metadata_with_unicode_succeeds() {
 
         // Verify metadata was stored correctly
         if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(memory.metadata, Some(metadata.to_string()));
         }
     }
@@ -218,7 +218,7 @@ fn test_ingest_content_with_combining_characters_succeeds() {
 
         // Verify content was stored as-input (deterministic behavior)
         if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(
                 memory.content, content,
                 "Content should be stored exactly as provided"
@@ -255,7 +255,7 @@ fn test_ingest_content_with_emoji_succeeds() {
 
         // Verify content was stored correctly
         if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, "test-project").unwrap().unwrap();
             assert_eq!(memory.content, content);
         }
     }
@@ -285,7 +285,7 @@ fn test_ingest_content_with_bom_succeeds() {
 
     // Verify content was stored with BOM intact (deterministic behavior)
     if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-        let memory = store.get(&id).unwrap().unwrap();
+        let memory = store.get(&id, "test-project").unwrap().unwrap();
         assert_eq!(
             memory.content, content_with_bom,
             "BOM should be preserved in storage"
@@ -328,7 +328,7 @@ fn test_ingest_accepts_any_project_id_string() {
 
         // Verify memory is associated with the project_id
         if let Ok(crate::memory_types::AddResult::Added { id }) = result {
-            let memory = store.get(&id).unwrap().unwrap();
+            let memory = store.get(&id, project_id).unwrap().unwrap();
             assert_eq!(memory.project_id, project_id);
         }
     }

--- a/src/memory/tests/search.rs
+++ b/src/memory/tests/search.rs
@@ -333,7 +333,7 @@ fn test_integration_add_search_roundtrip() {
         .unwrap();
     assert!(!results.is_empty());
 
-    let memory = store.get(&id).unwrap().unwrap();
+    let memory = store.get(&id, "test-project").unwrap().unwrap();
     assert_eq!(memory.content, "semantic search is useful");
 }
 
@@ -369,6 +369,6 @@ fn test_integration_update_changes_embedding() {
         .update(&id, Some("completely different content"), None, None, None)
         .unwrap();
 
-    let memory = store.get(&id).unwrap().unwrap();
+    let memory = store.get(&id, "test-project").unwrap().unwrap();
     assert_eq!(memory.content, "completely different content");
 }

--- a/src/sqlite/crud_tests.rs
+++ b/src/sqlite/crud_tests.rs
@@ -21,7 +21,7 @@ mod crud_tests {
             .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
-        let memory = db.get(&id).unwrap();
+        let memory = db.get(&id, "proj1").unwrap();
         assert!(memory.is_some());
         let m = memory.unwrap();
         assert_eq!(m.content, "test content");
@@ -43,7 +43,7 @@ mod crud_tests {
             )
             .unwrap();
 
-        let m = db.get(&id).unwrap().unwrap();
+        let m = db.get(&id, "proj1").unwrap().unwrap();
         assert_eq!(m.metadata, Some(r#"{"key": "value"}"#.to_string()));
     }
 
@@ -58,7 +58,7 @@ mod crud_tests {
     #[test]
     fn test_get_nonexistent() {
         let db = create_test_db();
-        let memory = db.get("nonexistent").unwrap();
+        let memory = db.get("nonexistent", "proj1").unwrap();
         assert!(memory.is_none());
     }
 
@@ -73,7 +73,7 @@ mod crud_tests {
         db.update(&id, Some("updated"), Some(&embedding), None, None, None)
             .unwrap();
 
-        let m = db.get(&id).unwrap().unwrap();
+        let m = db.get(&id, "proj1").unwrap().unwrap();
         assert_eq!(m.content, "updated");
     }
 
@@ -100,17 +100,17 @@ mod crud_tests {
             .insert("proj1", "content", &embedding, None, "fact", "active")
             .unwrap();
 
-        let deleted = db.delete(&id).unwrap();
+        let deleted = db.delete(&id, "proj1").unwrap();
         assert!(deleted);
 
-        let memory = db.get(&id).unwrap();
+        let memory = db.get(&id, "proj1").unwrap();
         assert!(memory.is_none());
     }
 
     #[test]
     fn test_delete_nonexistent() {
         let db = create_test_db();
-        let deleted = db.delete("nonexistent").unwrap();
+        let deleted = db.delete("nonexistent", "proj1").unwrap();
         assert!(!deleted);
     }
 
@@ -132,6 +132,55 @@ mod crud_tests {
         assert_eq!(list2[0].project_id, "proj2");
     }
 
+    /// Security: get() must not return memories belonging to other projects.
+    #[test]
+    fn test_get_cross_project_isolation() {
+        let db = create_test_db();
+        let embedding = vec![0.1f32; 384];
+        let id = db
+            .insert("proj1", "secret content", &embedding, None, "fact", "active")
+            .unwrap();
+
+        // proj1 can access its own memory
+        let found = db.get(&id, "proj1").unwrap();
+        assert!(found.is_some(), "proj1 should access its own memory");
+
+        // proj2 must NOT access proj1's memory
+        let not_found = db.get(&id, "proj2").unwrap();
+        assert!(
+            not_found.is_none(),
+            "proj2 must not access proj1's memory (cross-project isolation)"
+        );
+    }
+
+    /// Security: delete() must not delete memories belonging to other projects.
+    #[test]
+    fn test_delete_cross_project_isolation() {
+        let db = create_test_db();
+        let embedding = vec![0.1f32; 384];
+        let id = db
+            .insert("proj1", "content to protect", &embedding, None, "fact", "active")
+            .unwrap();
+
+        // proj2 must NOT delete proj1's memory
+        let deleted = db.delete(&id, "proj2").unwrap();
+        assert!(
+            !deleted,
+            "proj2 must not delete proj1's memory (cross-project isolation)"
+        );
+
+        // Verify memory still exists in proj1
+        let still_exists = db.get(&id, "proj1").unwrap();
+        assert!(
+            still_exists.is_some(),
+            "proj1 memory should survive a cross-project delete attempt"
+        );
+
+        // proj1 can delete its own memory
+        let deleted = db.delete(&id, "proj1").unwrap();
+        assert!(deleted, "proj1 should be able to delete its own memory");
+    }
+
     #[test]
     fn test_get_includes_embedding() {
         let db = create_test_db();
@@ -140,7 +189,7 @@ mod crud_tests {
             .insert("proj1", "test content", &embedding, None, "fact", "active")
             .unwrap();
 
-        let memory = db.get(&id).unwrap().unwrap();
+        let memory = db.get(&id, "proj1").unwrap().unwrap();
         assert_eq!(memory.embedding.len(), EMBEDDING_DIMS);
         for (i, &val) in embedding.iter().enumerate() {
             assert!((memory.embedding[i] - val).abs() < 1e-6);
@@ -179,7 +228,7 @@ mod crud_tests {
             .insert("proj1", "test", &full_embedding, None, "fact", "active")
             .unwrap();
 
-        let memory = db.get(&id).unwrap().unwrap();
+        let memory = db.get(&id, "proj1").unwrap().unwrap();
         assert_eq!(memory.embedding.len(), EMBEDDING_DIMS);
         assert!((memory.embedding[0] - original[0]).abs() < 1e-6);
         assert!((memory.embedding[1] - original[1]).abs() < 1e-6);

--- a/src/sqlite/fts.rs
+++ b/src/sqlite/fts.rs
@@ -347,7 +347,7 @@ mod tests {
             1
         );
 
-        db.delete(&id).unwrap();
+        db.delete(&id, "proj1").unwrap();
         assert_eq!(
             db.search_bm25("updated", "proj1", 10, None, None)
                 .unwrap()

--- a/src/sqlite/fts_tests.rs
+++ b/src/sqlite/fts_tests.rs
@@ -64,7 +64,7 @@ mod tests {
             1
         );
 
-        db.delete(&id).unwrap();
+        db.delete(&id, "proj1").unwrap();
         assert_eq!(
             db.search_bm25("updated", "proj1", 10, None, None)
                 .unwrap()

--- a/src/sqlite/mod.rs
+++ b/src/sqlite/mod.rs
@@ -251,37 +251,40 @@ impl Database {
         Ok(id)
     }
 
-    /// Retrieve a single memory by ID.
+    /// Retrieve a single memory by ID scoped to a project.
     ///
-    /// Returns None if the memory does not exist.
+    /// Returns None if the memory does not exist or belongs to a different project.
     ///
     /// # Errors
     ///
     /// Returns error if the database query fails.
-    pub fn get(&self, id: &str) -> Result<Option<Memory>> {
+    pub fn get(&self, id: &str, project_id: &str) -> Result<Option<Memory>> {
         let mut stmt = self.conn.prepare(
             r#"
             SELECT id, project_id, content, metadata, embedding, created_at, updated_at, type, status, superseded_by, retrieval_count, last_retrieved_at
             FROM memories
-            WHERE id = ?1
+            WHERE id = ?1 AND project_id = ?2
             "#,
         )?;
 
-        let result = stmt.query_row([id], map_row_to_memory).optional()?;
+        let result = stmt
+            .query_row([id, project_id], map_row_to_memory)
+            .optional()?;
         Ok(result)
     }
 
-    /// Delete a memory by ID.
+    /// Delete a memory by ID scoped to a project.
     ///
-    /// Returns true if a memory was deleted, false if it didn't exist.
+    /// Returns true if a memory was deleted, false if it didn't exist or belongs to a different project.
     ///
     /// # Errors
     ///
     /// Returns error if the database query fails.
-    pub fn delete(&self, id: &str) -> Result<bool> {
-        let rows = self
-            .conn
-            .execute("DELETE FROM memories WHERE id = ?1", [id])?;
+    pub fn delete(&self, id: &str, project_id: &str) -> Result<bool> {
+        let rows = self.conn.execute(
+            "DELETE FROM memories WHERE id = ?1 AND project_id = ?2",
+            [id, project_id],
+        )?;
         Ok(rows > 0)
     }
 

--- a/src/sqlite/supersede.rs
+++ b/src/sqlite/supersede.rs
@@ -21,9 +21,9 @@ impl super::Database {
         memory_type: &str,
         old_id: &str,
     ) -> Result<String> {
-        // Verify old memory exists
+        // Verify old memory exists and belongs to this project (scoped get enforces it)
         let old = self
-            .get(old_id)?
+            .get(old_id, project_id)?
             .ok_or_else(|| Error::NotFound(format!("memory to supersede not found: {}", old_id)))?;
         if old.project_id != project_id {
             return Err(Error::InvalidInput(

--- a/tests/lib_integration.rs
+++ b/tests/lib_integration.rs
@@ -251,7 +251,7 @@ fn test_memory_with_stored_content_returns_expected_fields() {
 
     // Get the memory
     let memory = store
-        .get(&memory_id)
+        .get(&memory_id, "test-project")
         .expect("Failed to get memory")
         .expect("Memory not found");
 
@@ -1169,13 +1169,19 @@ fn test_ingest_with_metadata_succeeds() {
     };
 
     // Verify metadata was stored
-    let memory1 = store.get(&id1).expect("Failed to get").expect("Not found");
+    let memory1 = store
+        .get(&id1, "test-project")
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(
         memory1.metadata.as_ref().unwrap(),
         r#"{"source": "manual"}"#
     );
 
-    let memory2 = store.get(&id2).expect("Failed to get").expect("Not found");
+    let memory2 = store
+        .get(&id2, "test-project")
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(
         memory2.metadata.as_ref().unwrap(),
         r#"{"source": "import"}"#
@@ -1218,7 +1224,10 @@ fn test_update_text_only_preserves_metadata() {
         .expect("Failed to update");
 
     // Verify content updated but metadata preserved
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "updated content");
     assert_eq!(memory.metadata.as_ref().unwrap(), r#"{"tag": "important"}"#);
 
@@ -1264,7 +1273,10 @@ fn test_update_with_invalid_json_metadata_returns_error() {
     }
 
     // Verify memory was not changed
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "original content");
     assert!(memory.metadata.is_none());
 
@@ -1310,7 +1322,10 @@ fn test_update_with_empty_metadata_returns_error() {
     }
 
     // Verify memory was not changed
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "original content");
     assert!(memory.metadata.is_none());
 
@@ -1356,7 +1371,10 @@ fn test_update_with_whitespace_only_metadata_returns_error() {
     }
 
     // Verify memory was not changed
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "original content");
     assert!(memory.metadata.is_none());
 
@@ -1397,7 +1415,10 @@ fn test_update_metadata_only() {
         .expect("Failed to update");
 
     // Verify metadata added but content unchanged
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "original content");
     assert_eq!(memory.metadata.as_ref().unwrap(), r#"{"tag": "new"}"#);
 
@@ -1444,7 +1465,10 @@ fn test_update_both_text_and_metadata() {
         .expect("Failed to update");
 
     // Verify both updated
-    let memory = store.get(&id).expect("Failed to get").expect("Not found");
+    let memory = store
+        .get(&id, project_id)
+        .expect("Failed to get")
+        .expect("Not found");
     assert_eq!(memory.content, "new content");
     assert_eq!(memory.metadata.as_ref().unwrap(), r#"{"new": "value"}"#);
 
@@ -1501,11 +1525,11 @@ fn test_add_with_conflict_creates_multiple_active_memories() {
 
     // Verify both memories exist and are active
     let memory_a = store
-        .get(&memory_a_id)
+        .get(&memory_a_id, &project_id)
         .expect("Failed to get memory A")
         .expect("Memory A not found");
     let memory_b = store
-        .get(&memory_b_id)
+        .get(&memory_b_id, &project_id)
         .expect("Failed to get memory B")
         .expect("Memory B not found");
 
@@ -1809,7 +1833,7 @@ fn test_supersede_through_public_api() {
 
     // Verify original is active
     let original = store
-        .get(&original_id)
+        .get(&original_id, &project_id)
         .expect("Failed to get original")
         .expect("Original memory not found");
     assert_eq!(original.status, "active");
@@ -1831,7 +1855,7 @@ fn test_supersede_through_public_api() {
 
     // Step 3: Verify old memory is now superseded
     let superseded = store
-        .get(&original_id)
+        .get(&original_id, &project_id)
         .expect("Failed to get superseded memory")
         .expect("Superseded memory not found");
     assert_eq!(superseded.status, "superseded");
@@ -1845,7 +1869,7 @@ fn test_supersede_through_public_api() {
 
     // Step 4: Verify new memory exists and is active
     let new_memory = store
-        .get(&new_id)
+        .get(&new_id, &project_id)
         .expect("Failed to get new memory")
         .expect("New memory not found");
     assert_eq!(new_memory.status, "active");
@@ -1890,7 +1914,7 @@ fn test_get_no_touch_preserves_count() {
 
     // Get the memory to see count
     let memory = store
-        .get(&memory_id)
+        .get(&memory_id, project_id)
         .expect("Failed to get memory")
         .expect("Memory not found");
     assert_eq!(memory.retrieval_count, 1);
@@ -1928,19 +1952,19 @@ fn test_touch_memories_increments_retrieval_count() {
     };
 
     // Verify initial count is 0
-    let mem = store.get(&id).unwrap().unwrap();
+    let mem = store.get(&id, &project_id).unwrap().unwrap();
     assert_eq!(mem.retrieval_count, 0);
     assert!(mem.last_retrieved_at.is_none());
 
     // Touch once
     store.touch_memories(&[&id]).unwrap();
-    let mem = store.get(&id).unwrap().unwrap();
+    let mem = store.get(&id, &project_id).unwrap().unwrap();
     assert_eq!(mem.retrieval_count, 1);
     assert!(mem.last_retrieved_at.is_some());
 
     // Touch again
     store.touch_memories(&[&id]).unwrap();
-    let mem = store.get(&id).unwrap().unwrap();
+    let mem = store.get(&id, &project_id).unwrap().unwrap();
     assert_eq!(mem.retrieval_count, 2);
 
     std::fs::remove_file(db_path).ok();


### PR DESCRIPTION
Bridges the gap between the vipune CLI (9 commands) and MCP server (previously 4 tools).

## New MCP tools
- `get_memory(id, no_touch?)` — retrieve a specific memory by ID
- `delete_memory(id)` — permanently delete a memory
- `update_memory(id, text?, metadata?, memory_type?, status?)` — mutate an existing memory (at least one field required)

## Extended params
- `store_memory` gains `force` param — bypass conflict detection when `true`
- `search_memories` gains `no_touch` param — skip retrieval telemetry update

## Implementation
- All tools follow existing rmcp `#[tool]` macro pattern
- New `StoreWrapper` methods: `get()`, `delete()`, `update()`, `touch_memories()`, `search_raw()`, `search_hybrid_raw()` — no direct `.0.lock()` access in tools.rs
- `helpers.rs` — shared `format_memory_json()` helper eliminates duplication
- 3 new `tokio::test` integration tests for all new tools
- 175 tests passing, clippy clean

Fixes #128