### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-15
+
+
 ## [0.5.0] - 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vipune"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vipune"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vipune`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `vipune` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  vipune::memory::MemoryStore::get takes 1 parameters in /tmp/.tmpoXpnoe/vipune/src/memory/crud.rs:206, but now takes 2 parameters in /tmp/.tmpZ89OLV/vipune/src/memory/crud.rs:211
  vipune::memory::MemoryStore::delete takes 1 parameters in /tmp/.tmpoXpnoe/vipune/src/memory/crud.rs:321, but now takes 2 parameters in /tmp/.tmpZ89OLV/vipune/src/memory/crud.rs:331
  vipune::MemoryStore::get takes 1 parameters in /tmp/.tmpoXpnoe/vipune/src/memory/crud.rs:206, but now takes 2 parameters in /tmp/.tmpZ89OLV/vipune/src/memory/crud.rs:211
  vipune::MemoryStore::delete takes 1 parameters in /tmp/.tmpoXpnoe/vipune/src/memory/crud.rs:321, but now takes 2 parameters in /tmp/.tmpZ89OLV/vipune/src/memory/crud.rs:331
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).